### PR TITLE
MIK-47: Add backend-driven runtime state auto-refresh

### DIFF
--- a/apps/api/config/urls.py
+++ b/apps/api/config/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from symphony.api.views import (
     healthcheck,
     runtime_dashboard,
+    runtime_events,
     runtime_issue,
     runtime_refresh,
     runtime_state,
@@ -15,6 +16,7 @@ urlpatterns = [
     path("healthz", healthcheck, name="healthcheck"),
     path("api/v1/state", runtime_state, name="runtime-state"),
     path("api/v1/refresh", runtime_refresh, name="runtime-refresh"),
+    path("api/v1/events", runtime_events, name="runtime-events"),
     path(
         "api/v1/tracker/issues/<str:issue_identifier>/comments",
         tracker_comment,

--- a/apps/api/symphony/api/views.py
+++ b/apps/api/symphony/api/views.py
@@ -2,12 +2,21 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Iterator
 from html import escape
+from typing import Any
 from urllib.parse import quote
 
-from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.http import (
+    HttpRequest,
+    HttpResponse,
+    HttpResponseBase,
+    JsonResponse,
+    StreamingHttpResponse,
+)
 from django.views.decorators.csrf import csrf_exempt
 
+from symphony.observability.events import wait_for_runtime_invalidation
 from symphony.observability.runtime import (
     RuntimeIssueNotFoundError,
     RuntimeSnapshotUnavailableError,
@@ -39,7 +48,9 @@ ALLOWED_DASHBOARD_METHODS = "GET, HEAD"
 ALLOWED_STATE_METHODS = "GET, HEAD"
 ALLOWED_ISSUE_METHODS = "GET, HEAD"
 ALLOWED_REFRESH_METHODS = "POST"
+ALLOWED_EVENTS_METHODS = "GET"
 ALLOWED_TRACKER_MUTATION_METHODS = "POST"
+RUNTIME_EVENTS_KEEPALIVE_SECONDS = 15.0
 
 
 def healthcheck(_request: HttpRequest) -> JsonResponse:
@@ -169,6 +180,44 @@ def runtime_refresh(request: HttpRequest) -> JsonResponse:
         return _error_response(code="timeout", message=str(exc), status=503)
 
     return JsonResponse(refresh_request, status=202)
+
+
+@csrf_exempt
+def runtime_events(request: HttpRequest) -> HttpResponseBase:
+    if request.method != "GET":
+        response = _error_response(
+            code="method_not_allowed",
+            message=f"Method {request.method!r} is not allowed for /api/v1/events.",
+            status=405,
+        )
+        response["Allow"] = ALLOWED_EVENTS_METHODS
+        return response
+
+    last_event_id = _parse_last_event_id(
+        request.headers.get("Last-Event-ID") or request.GET.get("lastEventId")
+    )
+
+    def stream_events() -> Iterator[str]:
+        current_sequence = last_event_id
+        yield ": connected\n\n"
+        while True:
+            event = wait_for_runtime_invalidation(
+                after_sequence=current_sequence,
+                timeout_seconds=RUNTIME_EVENTS_KEEPALIVE_SECONDS,
+            )
+            if event is None:
+                yield ": keepalive\n\n"
+                continue
+            current_sequence = int(event["sequence"])
+            yield _format_sse_event(event)
+
+    stream_response = StreamingHttpResponse(
+        streaming_content=stream_events(),
+        content_type="text/event-stream",
+    )
+    stream_response["Cache-Control"] = "no-cache"
+    stream_response["X-Accel-Buffering"] = "no"
+    return stream_response
 
 
 @csrf_exempt
@@ -321,6 +370,30 @@ def _error_response(*, code: str, message: str, status: int) -> JsonResponse:
     return JsonResponse(
         {"error": {"code": code, "message": message}},
         status=status,
+    )
+
+
+def _parse_last_event_id(raw_value: str | None) -> int | None:
+    if raw_value is None:
+        return None
+
+    stripped = raw_value.strip()
+    if not stripped:
+        return None
+
+    try:
+        return max(int(stripped), 0)
+    except ValueError:
+        return None
+
+
+def _format_sse_event(event: dict[str, Any]) -> str:
+    return "".join(
+        [
+            f"id: {event['sequence']}\n",
+            f"event: {event['event']}\n",
+            f"data: {json.dumps(event, sort_keys=True)}\n\n",
+        ]
     )
 
 

--- a/apps/api/symphony/observability/README.md
+++ b/apps/api/symphony/observability/README.md
@@ -1,3 +1,16 @@
 # Observability Module
 
-Owns structured logging, runtime snapshots, and operator-facing summaries.
+Owns structured logging, runtime snapshots, runtime invalidation events, and
+operator-facing summaries.
+
+Runtime refresh notes:
+
+- Runtime snapshots remain the canonical observability payload consumed by the
+  dashboard and issue-detail REST endpoints.
+- Runtime invalidation events are lightweight hints that tell browsers to
+  re-fetch those REST snapshots. They do not carry full runtime state.
+- The SSE invalidation stream is intentionally scoped to low-concurrency
+  internal usage on the current WSGI sidecar. Each open stream holds a worker
+  thread for the lifetime of the connection.
+- The invalidation broker is process-local in memory, so streamed invalidations
+  are only visible to clients connected to the same sidecar process.

--- a/apps/api/symphony/observability/__init__.py
+++ b/apps/api/symphony/observability/__init__.py
@@ -1,3 +1,13 @@
+from .events import (
+    clear_runtime_invalidations,
+    publish_runtime_invalidation,
+    wait_for_runtime_invalidation,
+)
 from .logging import log_event
 
-__all__ = ["log_event"]
+__all__ = [
+    "clear_runtime_invalidations",
+    "log_event",
+    "publish_runtime_invalidation",
+    "wait_for_runtime_invalidation",
+]

--- a/apps/api/symphony/observability/events.py
+++ b/apps/api/symphony/observability/events.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import copy
+import threading
+import time
+from collections import deque
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from .snapshots import isoformat_utc
+
+DEFAULT_RUNTIME_INVALIDATION_HISTORY_LIMIT = 128
+
+_invalidation_condition = threading.Condition()
+_invalidation_events: deque[dict[str, Any]] = deque(
+    maxlen=DEFAULT_RUNTIME_INVALIDATION_HISTORY_LIMIT
+)
+_next_invalidation_sequence = 0
+
+
+def publish_runtime_invalidation(
+    event_type: str,
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    event_payload = dict(payload or {})
+    event_payload.pop("sequence", None)
+    event_payload.pop("event", None)
+    event_payload.pop("emitted_at", None)
+
+    global _next_invalidation_sequence
+    with _invalidation_condition:
+        _next_invalidation_sequence += 1
+        event = {
+            "sequence": _next_invalidation_sequence,
+            "event": event_type,
+            "emitted_at": isoformat_utc(datetime.now(UTC)),
+            **event_payload,
+        }
+        _invalidation_events.append(event)
+        _invalidation_condition.notify_all()
+
+    return copy.deepcopy(event)
+
+
+def wait_for_runtime_invalidation(
+    *,
+    after_sequence: int | None,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    deadline = time.monotonic() + max(timeout_seconds, 0.0)
+    with _invalidation_condition:
+        event = _find_runtime_invalidation_locked(after_sequence)
+        if event is not None:
+            return copy.deepcopy(event)
+
+        while True:
+            remaining_seconds = deadline - time.monotonic()
+            if remaining_seconds <= 0:
+                return None
+
+            _invalidation_condition.wait(timeout=remaining_seconds)
+            event = _find_runtime_invalidation_locked(after_sequence)
+            if event is not None:
+                return copy.deepcopy(event)
+
+
+def clear_runtime_invalidations() -> None:
+    global _next_invalidation_sequence
+    with _invalidation_condition:
+        _invalidation_events.clear()
+        _next_invalidation_sequence = 0
+
+
+def _find_runtime_invalidation_locked(
+    after_sequence: int | None,
+) -> dict[str, Any] | None:
+    if not _invalidation_events:
+        return None
+
+    if after_sequence is None:
+        return _invalidation_events[-1]
+
+    for event in _invalidation_events:
+        if int(event["sequence"]) > after_sequence:
+            return event
+
+    return None

--- a/apps/api/symphony/observability/runtime.py
+++ b/apps/api/symphony/observability/runtime.py
@@ -14,6 +14,7 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Any, Protocol, cast
 
+from .events import publish_runtime_invalidation
 from .snapshots import isoformat_utc, parse_snapshot_timestamp, refresh_runtime_snapshot
 
 RUNTIME_SNAPSHOT_PATH_ENV_VAR = "SYMPHONY_RUNTIME_SNAPSHOT_PATH"
@@ -153,12 +154,14 @@ def queue_runtime_refresh_request(*, requested_at: datetime | None = None) -> di
             f"Runtime refresh request could not be written to {request_path}: {exc}."
         ) from exc
 
-    return {
+    response = {
         "queued": True,
         "coalesced": coalesced,
         "requested_at": active_request["requested_at"],
         "operations": active_request["operations"],
     }
+    publish_runtime_invalidation("refresh_queued", response)
+    return response
 
 
 def consume_runtime_refresh_request() -> dict[str, Any] | None:
@@ -318,6 +321,9 @@ def get_runtime_issue_snapshot(issue_identifier: str) -> dict[str, Any]:
     workspace = {"path": workspace_path} if isinstance(workspace_path, str) else None
 
     return {
+        "revision": snapshot.get("revision") if isinstance(snapshot.get("revision"), int) else 0,
+        "generated_at": snapshot.get("generated_at"),
+        "expires_at": snapshot.get("expires_at"),
         "issue_identifier": issue_identifier,
         "issue_id": issue_row.get("issue_id"),
         "status": "running" if running_row is not None else "retrying",

--- a/apps/api/symphony/observability/snapshots.py
+++ b/apps/api/symphony/observability/snapshots.py
@@ -12,6 +12,9 @@ def isoformat_utc(value: datetime | None) -> str | None:
 
 def refresh_runtime_snapshot(snapshot: dict[str, Any]) -> dict[str, Any]:
     generated_at = datetime.now(UTC)
+    revision = snapshot.get("revision")
+    if not isinstance(revision, int) or revision < 0:
+        snapshot["revision"] = 0
     base_generated_at = parse_snapshot_timestamp(snapshot.get("generated_at"))
     codex_totals = snapshot.get("codex_totals")
     running_rows = snapshot.get("running")

--- a/apps/api/symphony/orchestrator/core.py
+++ b/apps/api/symphony/orchestrator/core.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 from symphony.agent_runner import AgentRuntimeEvent, AttemptResult, run_issue_attempt
 from symphony.common.types import ServiceInfo
+from symphony.observability.events import publish_runtime_invalidation
 from symphony.observability.logging import log_event
 from symphony.observability.runtime import (
     RuntimeSnapshotUnavailableError,
@@ -169,8 +170,10 @@ class Orchestrator:
         self._runtime_snapshot_lock = threading.Lock()
         self._runtime_snapshot_task: asyncio.Task[None] | None = None
         self._runtime_snapshot_owner_token = uuid4().hex
+        self._runtime_snapshot_revision = 0
         self._runtime_snapshot: dict[str, Any] = self._build_runtime_snapshot(
-            generated_at=datetime.now(UTC)
+            generated_at=datetime.now(UTC),
+            revision=self._runtime_snapshot_revision,
         )
 
     async def startup(self) -> None:
@@ -1057,11 +1060,23 @@ class Orchestrator:
             return
 
     def _refresh_runtime_snapshot(self) -> None:
-        snapshot = self._build_runtime_snapshot(generated_at=datetime.now(UTC))
         with self._runtime_snapshot_lock:
+            previous_snapshot = copy.deepcopy(self._runtime_snapshot)
+            next_revision = self._runtime_snapshot_revision + 1
+
+        snapshot = self._build_runtime_snapshot(
+            generated_at=datetime.now(UTC),
+            revision=next_revision,
+        )
+        with self._runtime_snapshot_lock:
+            self._runtime_snapshot_revision = next_revision
             self._runtime_snapshot = snapshot
         self._publish_runtime_snapshot_best_effort(snapshot)
         self._publish_recovery_state_best_effort()
+        self._publish_runtime_invalidations(
+            previous_snapshot=previous_snapshot,
+            snapshot=snapshot,
+        )
 
     def _get_runtime_snapshot_refresh_interval_seconds(self) -> float:
         return get_runtime_snapshot_refresh_interval_seconds(
@@ -1261,7 +1276,7 @@ class Orchestrator:
             except TimeoutError:
                 continue
 
-    def _build_runtime_snapshot(self, *, generated_at: datetime) -> dict[str, Any]:
+    def _build_runtime_snapshot(self, *, generated_at: datetime, revision: int) -> dict[str, Any]:
         running_rows = [
             {
                 "issue_id": entry.issue.id,
@@ -1309,6 +1324,7 @@ class Orchestrator:
         )
 
         return {
+            "revision": revision,
             "generated_at": isoformat_utc(generated_at),
             "expires_at": isoformat_utc(
                 generated_at + timedelta(milliseconds=max(self.state.poll_interval_ms * 2, 1_000))
@@ -1331,6 +1347,36 @@ class Orchestrator:
             "rate_limits": copy.deepcopy(self.state.codex_rate_limits),
             "workflow": _workflow_runtime_snapshot(self._workflow_runtime),
         }
+
+    def _publish_runtime_invalidations(
+        self,
+        *,
+        previous_snapshot: dict[str, Any],
+        snapshot: dict[str, Any],
+    ) -> None:
+        revision = snapshot.get("revision")
+        revision_value = revision if isinstance(revision, int) else 0
+        publish_runtime_invalidation(
+            "snapshot_updated",
+            {
+                "revision": revision_value,
+                "generated_at": snapshot.get("generated_at"),
+                "expires_at": snapshot.get("expires_at"),
+            },
+        )
+
+        changed_issue_identifiers = _collect_changed_issue_identifiers(
+            previous_snapshot=previous_snapshot,
+            snapshot=snapshot,
+        )
+        if changed_issue_identifiers:
+            publish_runtime_invalidation(
+                "issue_changed",
+                {
+                    "revision": revision_value,
+                    "issue_identifiers": changed_issue_identifiers,
+                },
+            )
 
     def _get_live_config(self) -> ServiceConfig:
         return self.config
@@ -1605,6 +1651,40 @@ def _workflow_runtime_snapshot(workflow_runtime: WorkflowRuntime | None) -> dict
         "last_checked_at": isoformat_utc(status.last_checked_at),
         "last_error": last_error,
     }
+
+
+def _collect_changed_issue_identifiers(
+    *,
+    previous_snapshot: dict[str, Any],
+    snapshot: dict[str, Any],
+) -> list[str]:
+    previous_rows = _runtime_issue_rows_by_identifier(previous_snapshot)
+    current_rows = _runtime_issue_rows_by_identifier(snapshot)
+
+    changed_identifiers = [
+        identifier
+        for identifier in sorted(set(previous_rows) | set(current_rows))
+        if previous_rows.get(identifier) != current_rows.get(identifier)
+    ]
+    return changed_identifiers
+
+
+def _runtime_issue_rows_by_identifier(
+    snapshot: dict[str, Any],
+) -> dict[str, tuple[str, dict[str, Any]]]:
+    rows_by_identifier: dict[str, tuple[str, dict[str, Any]]] = {}
+    for status_key in ("running", "retrying"):
+        rows = snapshot.get(status_key)
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            issue_identifier = row.get("issue_identifier")
+            if not isinstance(issue_identifier, str) or not issue_identifier:
+                continue
+            rows_by_identifier[issue_identifier] = (status_key, row)
+    return rows_by_identifier
 
 
 def _error_code(exc: Exception) -> str:

--- a/apps/api/tests/unit/api/test_state.py
+++ b/apps/api/tests/unit/api/test_state.py
@@ -6,9 +6,15 @@ import tempfile
 from collections.abc import Generator, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 from django.test import Client
+from symphony.observability.events import (
+    clear_runtime_invalidations,
+    publish_runtime_invalidation,
+    wait_for_runtime_invalidation,
+)
 from symphony.observability.runtime import (
     DEFAULT_RUNTIME_REFRESH_REQUEST_FILENAME,
     DEFAULT_RUNTIME_SNAPSHOT_FILENAME,
@@ -39,11 +45,17 @@ class SilentTrackerClient:
 
 
 @pytest.fixture(autouse=True)
-def clear_snapshot_state() -> Generator[None, None, None]:
+def clear_snapshot_state(monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
+    monkeypatch.delenv("SYMPHONY_RUNTIME_SNAPSHOT_PATH", raising=False)
+    monkeypatch.delenv("SYMPHONY_RUNTIME_REFRESH_REQUEST_PATH", raising=False)
+    monkeypatch.delenv("SYMPHONY_RUNTIME_RECOVERY_PATH", raising=False)
+    monkeypatch.delenv("SYMPHONY_RUNTIME_SNAPSHOT_MAX_AGE_SECONDS", raising=False)
+    clear_runtime_invalidations()
     clear_runtime_snapshot_provider()
     _clear_snapshot_file_best_effort()
     _clear_refresh_request_file_best_effort()
     yield
+    clear_runtime_invalidations()
     clear_runtime_snapshot_provider()
     _clear_snapshot_file_best_effort()
     _clear_refresh_request_file_best_effort()
@@ -67,10 +79,11 @@ def build_config(*, tmp_path: Path) -> ServiceConfig:
     )
 
 
-def fresh_snapshot_times() -> dict[str, str]:
+def fresh_snapshot_times(*, revision: int = 1) -> dict[str, str | int]:
     generated_at = datetime.now(UTC)
     expires_at = generated_at + timedelta(minutes=5)
     return {
+        "revision": revision,
         "generated_at": generated_at.isoformat().replace("+00:00", "Z"),
         "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
     }
@@ -184,6 +197,7 @@ def test_state_endpoint_reads_snapshot_written_by_orchestrator(tmp_path: Path) -
 
             assert response.status_code == 200
             assert response.json()["counts"] == {"running": 0, "retrying": 0}
+            assert response.json()["revision"] >= 1
         finally:
             await orchestrator.aclose()
 
@@ -212,6 +226,7 @@ def test_state_endpoint_reads_default_snapshot_path_across_processes(
 
             assert response.status_code == 200
             assert response.json()["counts"] == {"running": 0, "retrying": 0}
+            assert response.json()["revision"] >= 1
         finally:
             await orchestrator.aclose()
 
@@ -246,6 +261,137 @@ def test_refresh_endpoint_queues_runtime_refresh_request() -> None:
     assert consumed_request == {
         "requested_at": payload["requested_at"],
         "operations": ["poll", "reconcile"],
+    }
+
+
+def test_refresh_endpoint_publishes_refresh_queued_invalidation_event() -> None:
+    response = Client().post("/api/v1/refresh", data={})
+
+    assert response.status_code == 202
+    event = wait_for_runtime_invalidation(after_sequence=None, timeout_seconds=0.1)
+    assert event is not None
+    assert event == {
+        "sequence": 1,
+        "event": "refresh_queued",
+        "emitted_at": event["emitted_at"],
+        "queued": True,
+        "coalesced": False,
+        "requested_at": response.json()["requested_at"],
+        "operations": ["poll", "reconcile"],
+    }
+
+
+def test_events_endpoint_streams_runtime_invalidations() -> None:
+    publish_runtime_invalidation(
+        "snapshot_updated",
+        {
+            "revision": 7,
+            "generated_at": "2026-03-11T11:00:00Z",
+            "expires_at": "2026-03-11T11:05:00Z",
+        },
+    )
+
+    response = Client().get("/api/v1/events")
+    try:
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("text/event-stream")
+        chunks = iter(_streaming_content(response))
+        assert _stream_chunk_text(next(chunks)) == ": connected\n\n"
+        event_chunk = _stream_chunk_text(next(chunks))
+        assert "id: 1" in event_chunk
+        assert "event: snapshot_updated" in event_chunk
+        assert '"revision": 7' in event_chunk
+    finally:
+        response.close()
+
+
+def test_events_endpoint_resumes_after_last_event_id_header() -> None:
+    publish_runtime_invalidation(
+        "snapshot_updated",
+        {
+            "revision": 4,
+            "generated_at": "2026-03-11T11:00:00Z",
+            "expires_at": "2026-03-11T11:05:00Z",
+        },
+    )
+    publish_runtime_invalidation(
+        "snapshot_updated",
+        {
+            "revision": 5,
+            "generated_at": "2026-03-11T11:01:00Z",
+            "expires_at": "2026-03-11T11:06:00Z",
+        },
+    )
+
+    response = Client().get("/api/v1/events", HTTP_LAST_EVENT_ID="1")
+    try:
+        assert response.status_code == 200
+        chunks = iter(_streaming_content(response))
+        assert _stream_chunk_text(next(chunks)) == ": connected\n\n"
+        event_chunk = _stream_chunk_text(next(chunks))
+        assert "id: 2" in event_chunk
+        assert "event: snapshot_updated" in event_chunk
+        assert '"revision": 5' in event_chunk
+    finally:
+        response.close()
+
+
+def test_events_endpoint_accepts_last_event_id_query_parameter() -> None:
+    publish_runtime_invalidation(
+        "snapshot_updated",
+        {
+            "revision": 2,
+            "generated_at": "2026-03-11T11:00:00Z",
+            "expires_at": "2026-03-11T11:05:00Z",
+        },
+    )
+    publish_runtime_invalidation(
+        "issue_changed",
+        {
+            "revision": 3,
+            "issue_identifiers": ["SYM-123"],
+        },
+    )
+
+    response = Client().get("/api/v1/events?lastEventId=1")
+    try:
+        assert response.status_code == 200
+        chunks = iter(_streaming_content(response))
+        assert _stream_chunk_text(next(chunks)) == ": connected\n\n"
+        event_chunk = _stream_chunk_text(next(chunks))
+        assert "id: 2" in event_chunk
+        assert "event: issue_changed" in event_chunk
+        assert '"issue_identifiers": ["SYM-123"]' in event_chunk
+        assert '"revision": 3' in event_chunk
+    finally:
+        response.close()
+
+
+def test_events_endpoint_emits_keepalive_when_idle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("symphony.api.views.RUNTIME_EVENTS_KEEPALIVE_SECONDS", 0.0)
+
+    response = Client().get("/api/v1/events")
+    try:
+        assert response.status_code == 200
+        chunks = iter(_streaming_content(response))
+        assert _stream_chunk_text(next(chunks)) == ": connected\n\n"
+        assert _stream_chunk_text(next(chunks)) == ": keepalive\n\n"
+    finally:
+        response.close()
+
+
+def test_events_endpoint_rejects_post_with_405_error_envelope() -> None:
+    response = Client().post("/api/v1/events", data={})
+
+    assert response.status_code == 405
+    assert response["Allow"] == "GET"
+    assert response.json() == {
+        "error": {
+            "code": "method_not_allowed",
+            "message": "Method 'POST' is not allowed for /api/v1/events.",
+        }
     }
 
 
@@ -300,9 +446,10 @@ def test_issue_endpoint_returns_503_error_envelope_when_snapshot_is_missing() ->
 
 
 def test_issue_endpoint_returns_running_issue_details() -> None:
+    snapshot_times = fresh_snapshot_times(revision=7)
     publish_runtime_snapshot(
         {
-            **fresh_snapshot_times(),
+            **snapshot_times,
             "counts": {"running": 1, "retrying": 0},
             "running": [
                 {
@@ -338,47 +485,50 @@ def test_issue_endpoint_returns_running_issue_details() -> None:
     response = Client().get("/api/v1/SYM-123")
 
     assert response.status_code == 200
-    assert response.json() == {
-        "issue_identifier": "SYM-123",
-        "issue_id": "issue-123",
-        "status": "running",
-        "workspace": {"path": "/tmp/symphony/SYM-123"},
-        "attempts": {
-            "restart_count": 1,
-            "current_retry_attempt": 2,
-        },
-        "running": {
-            "session_id": "thread-1-turn-2",
-            "turn_count": 7,
-            "state": "In Progress",
-            "started_at": "2026-03-10T09:55:00Z",
-            "last_event": "notification",
-            "last_message": "Working on tests",
-            "last_event_at": "2026-03-10T09:59:30Z",
-            "tokens": {
-                "input_tokens": 1200,
-                "output_tokens": 800,
-                "total_tokens": 2000,
-            },
-        },
-        "retry": None,
-        "logs": {"codex_session_logs": []},
-        "recent_events": [
-            {
-                "at": "2026-03-10T09:59:30Z",
-                "event": "notification",
-                "message": "Working on tests",
-            }
-        ],
-        "last_error": None,
-        "tracked": {},
+    payload = response.json()
+    assert payload["revision"] == 7
+    assert isinstance(payload["generated_at"], str)
+    assert payload["expires_at"] == snapshot_times["expires_at"]
+    assert payload["issue_identifier"] == "SYM-123"
+    assert payload["issue_id"] == "issue-123"
+    assert payload["status"] == "running"
+    assert payload["workspace"] == {"path": "/tmp/symphony/SYM-123"}
+    assert payload["attempts"] == {
+        "restart_count": 1,
+        "current_retry_attempt": 2,
     }
+    assert payload["running"] == {
+        "session_id": "thread-1-turn-2",
+        "turn_count": 7,
+        "state": "In Progress",
+        "started_at": "2026-03-10T09:55:00Z",
+        "last_event": "notification",
+        "last_message": "Working on tests",
+        "last_event_at": "2026-03-10T09:59:30Z",
+        "tokens": {
+            "input_tokens": 1200,
+            "output_tokens": 800,
+            "total_tokens": 2000,
+        },
+    }
+    assert payload["retry"] is None
+    assert payload["logs"] == {"codex_session_logs": []}
+    assert payload["recent_events"] == [
+        {
+            "at": "2026-03-10T09:59:30Z",
+            "event": "notification",
+            "message": "Working on tests",
+        }
+    ]
+    assert payload["last_error"] is None
+    assert payload["tracked"] == {}
 
 
 def test_issue_endpoint_returns_retry_issue_details() -> None:
+    snapshot_times = fresh_snapshot_times(revision=4)
     publish_runtime_snapshot(
         {
-            **fresh_snapshot_times(),
+            **snapshot_times,
             "counts": {"running": 0, "retrying": 1},
             "running": [],
             "retrying": [
@@ -404,26 +554,28 @@ def test_issue_endpoint_returns_retry_issue_details() -> None:
     response = Client().get("/api/v1/SYM-456")
 
     assert response.status_code == 200
-    assert response.json() == {
-        "issue_identifier": "SYM-456",
-        "issue_id": "issue-456",
-        "status": "retrying",
-        "workspace": {"path": "/tmp/symphony/SYM-456"},
-        "attempts": {
-            "restart_count": 2,
-            "current_retry_attempt": 3,
-        },
-        "running": None,
-        "retry": {
-            "attempt": 3,
-            "due_at": "2026-03-10T10:01:00Z",
-            "error": "no available orchestrator slots",
-        },
-        "logs": {"codex_session_logs": []},
-        "recent_events": [],
-        "last_error": "no available orchestrator slots",
-        "tracked": {},
+    payload = response.json()
+    assert payload["revision"] == 4
+    assert isinstance(payload["generated_at"], str)
+    assert payload["expires_at"] == snapshot_times["expires_at"]
+    assert payload["issue_identifier"] == "SYM-456"
+    assert payload["issue_id"] == "issue-456"
+    assert payload["status"] == "retrying"
+    assert payload["workspace"] == {"path": "/tmp/symphony/SYM-456"}
+    assert payload["attempts"] == {
+        "restart_count": 2,
+        "current_retry_attempt": 3,
     }
+    assert payload["running"] is None
+    assert payload["retry"] == {
+        "attempt": 3,
+        "due_at": "2026-03-10T10:01:00Z",
+        "error": "no available orchestrator slots",
+    }
+    assert payload["logs"] == {"codex_session_logs": []}
+    assert payload["recent_events"] == []
+    assert payload["last_error"] == "no available orchestrator slots"
+    assert payload["tracked"] == {}
 
 
 def test_issue_endpoint_returns_404_for_unknown_issue_in_snapshot() -> None:
@@ -619,3 +771,13 @@ def _clear_refresh_request_file_best_effort() -> None:
         clear_runtime_refresh_request_file()
     except RuntimeSnapshotUnavailableError:
         pass
+
+
+def _stream_chunk_text(chunk: bytes | str) -> str:
+    if isinstance(chunk, bytes):
+        return chunk.decode("utf-8")
+    return chunk
+
+
+def _streaming_content(response: object) -> Any:
+    return cast(Any, response).streaming_content

--- a/apps/api/tests/unit/orchestrator/test_core.py
+++ b/apps/api/tests/unit/orchestrator/test_core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import Generator, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
@@ -11,8 +11,16 @@ from typing import Any, cast
 import pytest
 from symphony.agent_runner import AgentRuntimeEvent, AttemptResult
 from symphony.agent_runner.events import UsageSnapshot
+from symphony.observability.events import (
+    clear_runtime_invalidations,
+    wait_for_runtime_invalidation,
+)
 from symphony.observability.runtime import (
     RuntimeSnapshotUnavailableError,
+    clear_runtime_refresh_request_file,
+    clear_runtime_snapshot_file,
+    clear_runtime_snapshot_provider,
+    configure_runtime_observability,
     get_runtime_issue_snapshot,
     get_runtime_recovery_path,
     get_runtime_refresh_request_path,
@@ -28,6 +36,33 @@ from symphony.workflow import WorkflowRuntime
 from symphony.workflow.config import ServiceConfig, build_service_config
 from symphony.workflow.loader import WorkflowDefinition
 from symphony.workspace import WorkspaceManager, WorkspaceRemoveError
+
+
+@pytest.fixture(autouse=True)
+def isolate_runtime_artifacts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    symphony_logger = logging.getLogger("symphony")
+    previous_propagate = symphony_logger.propagate
+    monkeypatch.delenv("SYMPHONY_RUNTIME_SNAPSHOT_PATH", raising=False)
+    monkeypatch.delenv("SYMPHONY_RUNTIME_REFRESH_REQUEST_PATH", raising=False)
+    monkeypatch.delenv("SYMPHONY_RUNTIME_RECOVERY_PATH", raising=False)
+    monkeypatch.delenv("SYMPHONY_RUNTIME_SNAPSHOT_MAX_AGE_SECONDS", raising=False)
+    symphony_logger.propagate = True
+    configure_runtime_observability()
+    clear_runtime_invalidations()
+    clear_runtime_snapshot_provider()
+    _clear_snapshot_file_best_effort()
+    _clear_refresh_request_file_best_effort()
+    _clear_recovery_file_best_effort()
+    yield
+    configure_runtime_observability()
+    clear_runtime_invalidations()
+    clear_runtime_snapshot_provider()
+    _clear_snapshot_file_best_effort()
+    _clear_refresh_request_file_best_effort()
+    _clear_recovery_file_best_effort()
+    symphony_logger.propagate = previous_propagate
 
 
 class FakeTrackerClient:
@@ -1641,6 +1676,73 @@ def test_orchestrator_refreshes_runtime_snapshot_immediately_after_dispatch(tmp_
     asyncio.run(run_test())
 
 
+def test_orchestrator_refreshes_runtime_revision_and_publishes_invalidations(
+    tmp_path: Path,
+) -> None:
+    config = build_config(tmp_path=tmp_path)
+    issue = build_issue(issue_id="issue-2", identifier="SYM-456")
+
+    async def pending_worker_runner() -> AttemptResult:
+        await asyncio.sleep(3600)
+        raise AssertionError("unreachable")
+
+    async def run_test() -> None:
+        orchestrator = Orchestrator(config=config, tracker_client=FakeTrackerClient())
+        worker_task: asyncio.Task[AttemptResult] | None = None
+        monitor_task: asyncio.Task[None] | None = None
+        try:
+            await orchestrator.startup()
+            initial_snapshot = orchestrator.get_runtime_snapshot()
+            assert initial_snapshot["revision"] == 1
+
+            clear_runtime_invalidations()
+            worker_task = asyncio.create_task(pending_worker_runner())
+            monitor_task = asyncio.create_task(asyncio.sleep(0))
+            orchestrator.state.running[issue.id] = RunningEntry(
+                issue=issue,
+                attempt=None,
+                worker_task=worker_task,
+                monitor_task=monitor_task,
+                workspace_path=tmp_path / "workspaces" / issue.identifier,
+                started_at=datetime.now(UTC),
+            )
+
+            orchestrator._refresh_runtime_snapshot()
+
+            refreshed_snapshot = orchestrator.get_runtime_snapshot()
+            assert refreshed_snapshot["revision"] == 2
+            assert refreshed_snapshot["counts"] == {"running": 1, "retrying": 0}
+            assert refreshed_snapshot["running"][0]["issue_identifier"] == issue.identifier
+
+            snapshot_event = wait_for_runtime_invalidation(
+                after_sequence=0,
+                timeout_seconds=0.1,
+            )
+            issue_event = wait_for_runtime_invalidation(
+                after_sequence=1,
+                timeout_seconds=0.1,
+            )
+
+            assert snapshot_event is not None
+            assert snapshot_event["event"] == "snapshot_updated"
+            assert snapshot_event["revision"] == 2
+            assert isinstance(snapshot_event["generated_at"], str)
+            assert isinstance(snapshot_event["expires_at"], str)
+
+            assert issue_event is not None
+            assert issue_event["event"] == "issue_changed"
+            assert issue_event["revision"] == 2
+            assert issue_event["issue_identifiers"] == [issue.identifier]
+        finally:
+            await orchestrator.aclose()
+            if worker_task is not None:
+                await asyncio.gather(worker_task, return_exceptions=True)
+            if monitor_task is not None:
+                await asyncio.gather(monitor_task, return_exceptions=True)
+
+    asyncio.run(run_test())
+
+
 def test_orchestrator_tolerates_runtime_snapshot_publish_failures(tmp_path: Path) -> None:
     config = build_config(tmp_path=tmp_path)
 
@@ -2281,3 +2383,21 @@ def test_orchestrator_wait_cycle_consumes_refresh_requests_early(tmp_path: Path)
             await orchestrator.aclose()
 
     asyncio.run(run_test())
+
+
+def _clear_snapshot_file_best_effort() -> None:
+    try:
+        clear_runtime_snapshot_file()
+    except RuntimeSnapshotUnavailableError:
+        pass
+
+
+def _clear_refresh_request_file_best_effort() -> None:
+    try:
+        clear_runtime_refresh_request_file()
+    except RuntimeSnapshotUnavailableError:
+        pass
+
+
+def _clear_recovery_file_best_effort() -> None:
+    get_runtime_recovery_path().unlink(missing_ok=True)

--- a/apps/web/src/app/features/dashboard/dashboard-page.component.ts
+++ b/apps/web/src/app/features/dashboard/dashboard-page.component.ts
@@ -15,7 +15,8 @@ import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatIconModule } from "@angular/material/icon";
 import { MatRippleModule } from "@angular/material/core";
 
-import { RuntimeApiService } from "../../shared/api/runtime-api.service";
+import { RuntimeSessionService } from "../../shared/api/runtime-session.service";
+import { presentDashboardSnapshot } from "../../shared/lib/runtime-presenters";
 import {
   DashboardViewModel,
   RefreshReceiptViewModel,
@@ -84,6 +85,11 @@ type RefreshState =
                 @if (refreshError(); as err) {
                   <span class="tone-danger refresh-hint"
                     >Refresh failed: {{ err.message }}</span
+                  >
+                }
+                @if (runtimeRefreshError(); as err) {
+                  <span class="tone-warning refresh-hint"
+                    >Auto-refresh failed: {{ err.message }}</span
                   >
                 }
                 <button
@@ -477,12 +483,35 @@ type RefreshState =
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DashboardPageComponent {
-  private readonly runtimeApi = inject(RuntimeApiService);
+  private readonly runtimeSession = inject(RuntimeSessionService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly runtimeState = this.runtimeSession.watchState(this.destroyRef);
 
-  readonly state = signal<DashboardState>({ kind: "loading" });
   readonly expandedIssues = signal(new Set<string>());
   readonly refreshState = signal<RefreshState>({ kind: "idle" });
+  readonly state = computed<DashboardState>(() => {
+    const loadState = this.runtimeState.loadState();
+    if (loadState.initialLoadPending && loadState.snapshot === null) {
+      return { kind: "loading" };
+    }
+    if (loadState.snapshot) {
+      return {
+        kind: "ready",
+        data: presentDashboardSnapshot(loadState.snapshot)
+      };
+    }
+    return {
+      kind: "error",
+      error:
+        loadState.error ??
+        ({
+          kind: "unexpected",
+          code: "unexpected",
+          message: "The dashboard could not load",
+          status: null
+        } satisfies RuntimeUiError)
+    };
+  });
   readonly dashboardData = computed(() => {
     const state = this.state();
     return state.kind === "ready" ? state.data : null;
@@ -499,26 +528,20 @@ export class DashboardPageComponent {
     const refreshState = this.refreshState();
     return refreshState.kind === "error" ? refreshState.error : null;
   });
+  readonly runtimeRefreshError = computed(() => {
+    const loadState = this.runtimeState.loadState();
+    return loadState.snapshot ? loadState.error : null;
+  });
 
-  constructor() {
-    this.load();
-  }
+  constructor() {}
 
   load(): void {
-    this.state.set({ kind: "loading" });
-    this.runtimeApi
-      .loadDashboard()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (data) => this.state.set({ kind: "ready", data }),
-        error: (error: RuntimeUiError) =>
-          this.state.set({ kind: "error", error })
-      });
+    this.runtimeState.refresh();
   }
 
   requestRefresh(): void {
     this.refreshState.set({ kind: "pending" });
-    this.runtimeApi
+    this.runtimeSession
       .requestRefresh()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({

--- a/apps/web/src/app/features/issues/issue-detail-page.component.ts
+++ b/apps/web/src/app/features/issues/issue-detail-page.component.ts
@@ -15,9 +15,14 @@ import { MatProgressBarModule } from "@angular/material/progress-bar";
 import { MatIconModule } from "@angular/material/icon";
 import { MatDividerModule } from "@angular/material/divider";
 
-import { RuntimeApiService } from "../../shared/api/runtime-api.service";
+import {
+  RuntimeResourceConnection,
+  RuntimeSessionService
+} from "../../shared/api/runtime-session.service";
+import { presentIssueSnapshot } from "../../shared/lib/runtime-presenters";
 import {
   IssueDetailViewModel,
+  RuntimeIssueApiResponse,
   RuntimeUiError
 } from "../../shared/lib/runtime-types";
 import { EmptyStateComponent } from "../../shared/ui/empty-state.component";
@@ -51,6 +56,11 @@ type IssueState =
             <mat-icon>arrow_back</mat-icon> Back to dashboard
           </a>
           <h2 class="detail-title">{{ issueIdentifier() }}</h2>
+          @if (runtimeRefreshError(); as error) {
+            <p class="tone-warning detail-warning">
+              Auto-refresh failed: {{ error.message }}
+            </p>
+          }
         </div>
         <span class="section-eyebrow tone-accent">Issue detail</span>
       </div>
@@ -204,6 +214,10 @@ type IssueState =
         font-weight: 600;
         margin: 0.25rem 0 0 0.5rem;
       }
+      .detail-warning {
+        margin: 0.5rem 0 0 0.5rem;
+        font-size: 0.875rem;
+      }
       .section-eyebrow {
         font-size: 0.75rem;
         text-transform: uppercase;
@@ -288,11 +302,44 @@ type IssueState =
 })
 export class IssueDetailPageComponent {
   private readonly route = inject(ActivatedRoute);
-  private readonly runtimeApi = inject(RuntimeApiService);
+  private readonly runtimeSession = inject(RuntimeSessionService);
   private readonly destroyRef = inject(DestroyRef);
+  private currentIssueResource: RuntimeResourceConnection<RuntimeIssueApiResponse> | null =
+    null;
 
-  readonly state = signal<IssueState>({ kind: "loading" });
   readonly issueIdentifier = signal("unknown");
+  readonly issueResource = signal<RuntimeResourceConnection<RuntimeIssueApiResponse> | null>(
+    null
+  );
+  readonly issueLoadState = computed(() => this.issueResource()?.loadState() ?? {
+    snapshot: null,
+    error: null,
+    initialLoadPending: true,
+    refreshPending: false
+  });
+  readonly state = computed<IssueState>(() => {
+    const loadState = this.issueLoadState();
+    if (loadState.initialLoadPending && loadState.snapshot === null) {
+      return { kind: "loading" };
+    }
+    if (loadState.snapshot) {
+      return {
+        kind: "ready",
+        data: presentIssueSnapshot(loadState.snapshot)
+      };
+    }
+    return {
+      kind: "error",
+      error:
+        loadState.error ??
+        ({
+          kind: "unexpected",
+          code: "unexpected",
+          message: "Issue detail failed to load",
+          status: null
+        } satisfies RuntimeUiError)
+    };
+  });
   readonly issueDetail = computed(() => {
     const state = this.state();
     return state.kind === "ready" ? state.data : null;
@@ -301,27 +348,29 @@ export class IssueDetailPageComponent {
     const state = this.state();
     return state.kind === "error" ? state.error : null;
   });
+  readonly runtimeRefreshError = computed(() => {
+    const loadState = this.issueLoadState();
+    return loadState.snapshot ? loadState.error : null;
+  });
 
   constructor() {
+    this.destroyRef.onDestroy(() => this.currentIssueResource?.destroy());
     this.route.paramMap
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((params) => {
         const identifier = params.get("id") ?? "unknown";
         this.issueIdentifier.set(identifier);
-        this.load(identifier);
+        this.currentIssueResource?.destroy();
+        this.currentIssueResource = this.runtimeSession.connectIssue(identifier);
+        this.issueResource.set(this.currentIssueResource);
       });
   }
 
   load(issueIdentifier: string): void {
-    this.state.set({ kind: "loading" });
-    this.runtimeApi
-      .loadIssue(issueIdentifier)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (data) => this.state.set({ kind: "ready", data }),
-        error: (error: RuntimeUiError) =>
-          this.state.set({ kind: "error", error })
-      });
+    if (issueIdentifier !== this.issueIdentifier()) {
+      this.issueIdentifier.set(issueIdentifier);
+    }
+    this.currentIssueResource?.refresh();
   }
 
   errorEyebrow(error: RuntimeUiError): string {

--- a/apps/web/src/app/shared/api/runtime-api.service.ts
+++ b/apps/web/src/app/shared/api/runtime-api.service.ts
@@ -24,31 +24,40 @@ import {
 export class RuntimeApiService {
   private readonly http = inject(HttpClient);
 
+  loadStateSnapshot(): Observable<RuntimeStateApiResponse> {
+    return this.http
+      .get<RuntimeStateApiResponse>("/api/v1/state")
+      .pipe(catchError((error: unknown) => throwError(() => toRuntimeUiError(error))));
+  }
+
   loadDashboard(): Observable<DashboardViewModel> {
-    return this.http.get<RuntimeStateApiResponse>("/api/v1/state").pipe(
+    return this.loadStateSnapshot().pipe(
       map((response) => presentDashboardSnapshot(response)),
-      catchError((error: unknown) => throwError(() => toRuntimeUiError(error)))
     );
   }
 
   loadRuns(): Observable<RunsViewModel> {
-    return this.http.get<RuntimeStateApiResponse>("/api/v1/state").pipe(
+    return this.loadStateSnapshot().pipe(
       map((response) => presentRunsSnapshot(response)),
-      catchError((error: unknown) => throwError(() => toRuntimeUiError(error)))
     );
   }
 
-  loadIssue(issueIdentifier: string): Observable<IssueDetailViewModel> {
+  loadIssueSnapshot(issueIdentifier: string): Observable<RuntimeIssueApiResponse> {
     return this.http
       .get<RuntimeIssueApiResponse>(
         `/api/v1/${encodeURIComponent(issueIdentifier)}`
       )
       .pipe(
-        map((response) => presentIssueSnapshot(response)),
         catchError((error: unknown) =>
           throwError(() => toRuntimeUiError(error))
         )
       );
+  }
+
+  loadIssue(issueIdentifier: string): Observable<IssueDetailViewModel> {
+    return this.loadIssueSnapshot(issueIdentifier).pipe(
+      map((response) => presentIssueSnapshot(response))
+    );
   }
 
   requestRefresh(): Observable<RefreshReceiptViewModel> {

--- a/apps/web/src/app/shared/api/runtime-session.service.ts
+++ b/apps/web/src/app/shared/api/runtime-session.service.ts
@@ -1,0 +1,461 @@
+import { DestroyRef, Injectable, Signal, WritableSignal, signal } from "@angular/core";
+import { Observable, Subscription, tap } from "rxjs";
+
+import { RuntimeApiService } from "./runtime-api.service";
+import {
+  RefreshReceiptViewModel,
+  RuntimeInvalidationEvent,
+  RuntimeIssueApiResponse,
+  RuntimeLoadState,
+  RuntimeStateApiResponse,
+  RuntimeUiError
+} from "../lib/runtime-types";
+
+const FALLBACK_REFRESH_DELAY_MS = 5_000;
+const EVENT_STREAM_RECONNECT_DELAY_MS = 1_000;
+const RUNTIME_EVENTS_URL = "/api/v1/events";
+
+type RuntimeManagedSnapshot = RuntimeStateApiResponse | RuntimeIssueApiResponse;
+
+type RuntimeManagedResource<TSnapshot extends RuntimeManagedSnapshot> = {
+  key: string;
+  loadSnapshot: () => Observable<TSnapshot>;
+  loadState: WritableSignal<RuntimeLoadState<TSnapshot>>;
+  watchCount: number;
+  timerHandle: ReturnType<typeof globalThis.setTimeout> | null;
+  requestSubscription: Subscription | null;
+  refreshQueued: boolean;
+};
+
+export interface RuntimeResourceHandle<TSnapshot extends RuntimeManagedSnapshot> {
+  loadState: Signal<RuntimeLoadState<TSnapshot>>;
+  refresh: () => void;
+}
+
+export interface RuntimeResourceConnection<
+  TSnapshot extends RuntimeManagedSnapshot
+> extends RuntimeResourceHandle<TSnapshot> {
+  destroy: () => void;
+}
+
+@Injectable({ providedIn: "root" })
+export class RuntimeSessionService {
+  private readonly stateResource: RuntimeManagedResource<RuntimeStateApiResponse>;
+  private readonly issueResources = new Map<
+    string,
+    RuntimeManagedResource<RuntimeIssueApiResponse>
+  >();
+  private readonly focusListener = () => this.refreshActiveResources();
+  private readonly visibilityListener = () => {
+    const browserDocument = getBrowserDocument();
+    if (!browserDocument || browserDocument.visibilityState === "visible") {
+      this.refreshActiveResources();
+    }
+  };
+  private readonly eventListener = (event: Event) => {
+    const messageEvent = event as MessageEvent<string>;
+    const invalidation = parseRuntimeInvalidationEvent(messageEvent.data);
+    if (invalidation) {
+      this.handleInvalidation(invalidation);
+    }
+  };
+  private readonly eventErrorListener = () => this.handleEventStreamError();
+  private browserListenersActive = false;
+  private eventSource: EventSource | null = null;
+  private eventSourceReconnectHandle: ReturnType<typeof globalThis.setTimeout> | null =
+    null;
+
+  constructor(
+    private readonly api: RuntimeApiService
+  ) {
+    this.stateResource = this.createResource("state", () =>
+      this.api.loadStateSnapshot()
+    );
+  }
+
+  watchState(
+    destroyRef: Pick<DestroyRef, "onDestroy">
+  ): RuntimeResourceHandle<RuntimeStateApiResponse> {
+    return this.attachResource(this.stateResource, destroyRef);
+  }
+
+  watchIssue(
+    issueIdentifier: string,
+    destroyRef: Pick<DestroyRef, "onDestroy">
+  ): RuntimeResourceHandle<RuntimeIssueApiResponse> {
+    const connection = this.connectIssue(issueIdentifier);
+    destroyRef.onDestroy(connection.destroy);
+    return connection;
+  }
+
+  connectIssue(
+    issueIdentifier: string
+  ): RuntimeResourceConnection<RuntimeIssueApiResponse> {
+    const existingResource = this.issueResources.get(issueIdentifier);
+    const resource =
+      existingResource ??
+      this.createIssueResource(issueIdentifier);
+    return this.connectResource(resource);
+  }
+
+  requestRefresh(): Observable<RefreshReceiptViewModel> {
+    return this.api.requestRefresh().pipe(tap(() => this.refreshActiveResources()));
+  }
+
+  private createIssueResource(
+    issueIdentifier: string
+  ): RuntimeManagedResource<RuntimeIssueApiResponse> {
+    const resource = this.createResource(issueIdentifier, () =>
+      this.api.loadIssueSnapshot(issueIdentifier)
+    );
+    this.issueResources.set(issueIdentifier, resource);
+    return resource;
+  }
+
+  private createResource<TSnapshot extends RuntimeManagedSnapshot>(
+    key: string,
+    loadSnapshot: () => Observable<TSnapshot>
+  ): RuntimeManagedResource<TSnapshot> {
+    return {
+      key,
+      loadSnapshot,
+      loadState: signal<RuntimeLoadState<TSnapshot>>({
+        snapshot: null,
+        error: null,
+        initialLoadPending: true,
+        refreshPending: false
+      }),
+      watchCount: 0,
+      timerHandle: null,
+      requestSubscription: null,
+      refreshQueued: false
+    };
+  }
+
+  private attachResource<TSnapshot extends RuntimeManagedSnapshot>(
+    resource: RuntimeManagedResource<TSnapshot>,
+    destroyRef: Pick<DestroyRef, "onDestroy">
+  ): RuntimeResourceHandle<TSnapshot> {
+    const connection = this.connectResource(resource);
+    destroyRef.onDestroy(connection.destroy);
+    return connection;
+  }
+
+  private connectResource<TSnapshot extends RuntimeManagedSnapshot>(
+    resource: RuntimeManagedResource<TSnapshot>
+  ): RuntimeResourceConnection<TSnapshot> {
+    resource.watchCount += 1;
+    this.ensureBrowserSubscriptions();
+    this.fetchResource(resource);
+    return {
+      loadState: resource.loadState.asReadonly(),
+      refresh: () => this.fetchResource(resource),
+      destroy: () => this.detachResource(resource)
+    };
+  }
+
+  private detachResource<TSnapshot extends RuntimeManagedSnapshot>(
+    resource: RuntimeManagedResource<TSnapshot>
+  ): void {
+    resource.watchCount = Math.max(resource.watchCount - 1, 0);
+    if (resource.watchCount > 0) {
+      return;
+    }
+
+    this.clearResourceTimer(resource);
+    resource.requestSubscription?.unsubscribe();
+    resource.requestSubscription = null;
+    resource.refreshQueued = false;
+    if (resource !== this.stateResource) {
+      this.issueResources.delete(resource.key);
+    }
+    this.teardownBrowserSubscriptionsIfIdle();
+  }
+
+  private fetchResource<TSnapshot extends RuntimeManagedSnapshot>(
+    resource: RuntimeManagedResource<TSnapshot>
+  ): void {
+    if (resource.watchCount <= 0) {
+      return;
+    }
+
+    if (resource.requestSubscription) {
+      resource.refreshQueued = true;
+      return;
+    }
+
+    const current = resource.loadState();
+    resource.loadState.set({
+      snapshot: current.snapshot,
+      error: null,
+      initialLoadPending: current.snapshot === null,
+      refreshPending: current.snapshot !== null
+    });
+    this.clearResourceTimer(resource);
+
+    let requestSubscription: Subscription | null = null;
+    requestSubscription = resource.loadSnapshot().subscribe({
+      next: (snapshot) => {
+        resource.loadState.set({
+          snapshot,
+          error: null,
+          initialLoadPending: false,
+          refreshPending: false
+        });
+        this.scheduleRefresh(resource, snapshot.expires_at);
+      },
+      error: (error) => {
+        if (resource.requestSubscription === requestSubscription) {
+          resource.requestSubscription = null;
+        }
+        resource.loadState.update((state) => ({
+          snapshot: state.snapshot,
+          error: error as RuntimeUiError,
+          initialLoadPending: false,
+          refreshPending: false
+        }));
+        this.scheduleRefresh(resource, null);
+      },
+      complete: () => {
+        if (resource.requestSubscription === requestSubscription) {
+          resource.requestSubscription = null;
+        }
+        if (resource.refreshQueued) {
+          resource.refreshQueued = false;
+          this.fetchResource(resource);
+        }
+      }
+    });
+    resource.requestSubscription = requestSubscription.closed
+      ? null
+      : requestSubscription;
+  }
+
+  private scheduleRefresh<TSnapshot extends RuntimeManagedSnapshot>(
+    resource: RuntimeManagedResource<TSnapshot>,
+    expiresAt: string | null
+  ): void {
+    if (resource.watchCount <= 0) {
+      return;
+    }
+
+    const delayMs = computeRuntimeRefreshDelay(expiresAt);
+    resource.timerHandle = globalThis.setTimeout(() => {
+      resource.timerHandle = null;
+      this.fetchResource(resource);
+    }, delayMs);
+  }
+
+  private clearResourceTimer<TSnapshot extends RuntimeManagedSnapshot>(
+    resource: RuntimeManagedResource<TSnapshot>
+  ): void {
+    if (resource.timerHandle !== null) {
+      globalThis.clearTimeout(resource.timerHandle);
+      resource.timerHandle = null;
+    }
+  }
+
+  private refreshActiveResources(): void {
+    if (this.stateResource.watchCount > 0) {
+      this.fetchResource(this.stateResource);
+    }
+    for (const resource of this.issueResources.values()) {
+      if (resource.watchCount > 0) {
+        this.fetchResource(resource);
+      }
+    }
+  }
+
+  private ensureBrowserSubscriptions(): void {
+    if (!this.browserListenersActive) {
+      const browserWindow = getBrowserWindow();
+      const browserDocument = getBrowserDocument();
+      browserWindow?.addEventListener("focus", this.focusListener);
+      browserDocument?.addEventListener(
+        "visibilitychange",
+        this.visibilityListener
+      );
+      this.browserListenersActive = true;
+    }
+
+    if (this.eventSource || this.activeWatcherCount() <= 0) {
+      return;
+    }
+
+    const EventSourceCtor = getEventSourceConstructor();
+    if (!EventSourceCtor) {
+      return;
+    }
+
+    const eventSource = new EventSourceCtor(RUNTIME_EVENTS_URL);
+    eventSource.addEventListener("snapshot_updated", this.eventListener);
+    eventSource.addEventListener("issue_changed", this.eventListener);
+    eventSource.addEventListener("refresh_queued", this.eventListener);
+    eventSource.addEventListener("error", this.eventErrorListener);
+    this.eventSource = eventSource;
+  }
+
+  private teardownBrowserSubscriptionsIfIdle(): void {
+    if (this.activeWatcherCount() > 0) {
+      return;
+    }
+
+    if (this.browserListenersActive) {
+      const browserWindow = getBrowserWindow();
+      const browserDocument = getBrowserDocument();
+      browserWindow?.removeEventListener("focus", this.focusListener);
+      browserDocument?.removeEventListener(
+        "visibilitychange",
+        this.visibilityListener
+      );
+      this.browserListenersActive = false;
+    }
+
+    if (this.eventSourceReconnectHandle !== null) {
+      globalThis.clearTimeout(this.eventSourceReconnectHandle);
+      this.eventSourceReconnectHandle = null;
+    }
+    this.eventSource?.close();
+    this.eventSource = null;
+  }
+
+  private activeWatcherCount(): number {
+    let watcherCount = this.stateResource.watchCount;
+    for (const resource of this.issueResources.values()) {
+      watcherCount += resource.watchCount;
+    }
+    return watcherCount;
+  }
+
+  private handleInvalidation(event: RuntimeInvalidationEvent): void {
+    const issueIdentifiers = event.issue_identifiers ?? [];
+    const revision = typeof event.revision === "number" ? event.revision : null;
+    const stateRevision = getSnapshotRevision(this.stateResource.loadState().snapshot);
+
+    if (this.stateResource.watchCount > 0 && shouldRefreshForRevision(stateRevision, revision)) {
+      this.fetchResource(this.stateResource);
+    }
+
+    if (issueIdentifiers.length === 0) {
+      for (const resource of this.issueResources.values()) {
+        const issueRevision = getSnapshotRevision(resource.loadState().snapshot);
+        if (resource.watchCount > 0 && shouldRefreshForRevision(issueRevision, revision)) {
+          this.fetchResource(resource);
+        }
+      }
+      return;
+    }
+
+    for (const issueIdentifier of issueIdentifiers) {
+      const resource = this.issueResources.get(issueIdentifier);
+      if (!resource || resource.watchCount <= 0) {
+        continue;
+      }
+      const issueRevision = getSnapshotRevision(resource.loadState().snapshot);
+      if (shouldRefreshForRevision(issueRevision, revision)) {
+        this.fetchResource(resource);
+      }
+    }
+  }
+
+  private handleEventStreamError(): void {
+    if (this.activeWatcherCount() <= 0) {
+      return;
+    }
+
+    this.eventSource?.close();
+    this.eventSource = null;
+    this.refreshActiveResources();
+    if (this.eventSourceReconnectHandle !== null) {
+      return;
+    }
+
+    this.eventSourceReconnectHandle = globalThis.setTimeout(() => {
+      this.eventSourceReconnectHandle = null;
+      this.refreshActiveResources();
+      this.ensureBrowserSubscriptions();
+    }, EVENT_STREAM_RECONNECT_DELAY_MS);
+  }
+}
+
+export function computeRuntimeRefreshDelay(expiresAt: string | null): number {
+  if (!expiresAt) {
+    return FALLBACK_REFRESH_DELAY_MS;
+  }
+
+  const expiresAtMs = new Date(expiresAt).getTime();
+  if (Number.isNaN(expiresAtMs)) {
+    return FALLBACK_REFRESH_DELAY_MS;
+  }
+
+  return Math.max(expiresAtMs - Date.now(), 0);
+}
+
+export function parseRuntimeInvalidationEvent(
+  rawValue: string
+): RuntimeInvalidationEvent | null {
+  try {
+    const parsed = JSON.parse(rawValue) as Partial<RuntimeInvalidationEvent>;
+    if (
+      typeof parsed.sequence !== "number" ||
+      typeof parsed.event !== "string" ||
+      typeof parsed.emitted_at !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      sequence: parsed.sequence,
+      event: parsed.event,
+      emitted_at: parsed.emitted_at,
+      revision:
+        typeof parsed.revision === "number" ? parsed.revision : undefined,
+      issue_identifiers: Array.isArray(parsed.issue_identifiers)
+        ? parsed.issue_identifiers.filter(
+            (value): value is string => typeof value === "string" && value.length > 0
+          )
+        : undefined
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getSnapshotRevision(
+  snapshot: RuntimeManagedSnapshot | null
+): number | null {
+  if (!snapshot || typeof snapshot.revision !== "number") {
+    return null;
+  }
+  return snapshot.revision;
+}
+
+function shouldRefreshForRevision(
+  currentRevision: number | null,
+  nextRevision: number | null
+): boolean {
+  if (nextRevision === null) {
+    return true;
+  }
+  if (currentRevision === null) {
+    return true;
+  }
+  return nextRevision > currentRevision;
+}
+
+function getBrowserWindow(): Window | null {
+  return typeof window === "undefined" ? null : window;
+}
+
+function getBrowserDocument(): Document | null {
+  return typeof document === "undefined" ? null : document;
+}
+
+function getEventSourceConstructor():
+  | (new (url: string) => EventSource)
+  | null {
+  if (typeof EventSource === "undefined") {
+    return null;
+  }
+  return EventSource;
+}

--- a/apps/web/src/app/shared/lib/runtime-types.ts
+++ b/apps/web/src/app/shared/lib/runtime-types.ts
@@ -1,3 +1,9 @@
+export interface RuntimeSnapshotMetaApiResponse {
+  revision: number;
+  generated_at: string;
+  expires_at: string;
+}
+
 export interface RuntimeCountsApiResponse {
   running: number;
   retrying: number;
@@ -66,9 +72,7 @@ export interface RateLimitsApiResponse {
   [key: string]: unknown;
 }
 
-export interface RuntimeStateApiResponse {
-  generated_at: string;
-  expires_at: string;
+export interface RuntimeStateApiResponse extends RuntimeSnapshotMetaApiResponse {
   counts: RuntimeCountsApiResponse;
   running: RuntimeRunningEntryApiResponse[];
   retrying: RuntimeRetryEntryApiResponse[];
@@ -107,7 +111,7 @@ export interface RuntimeIssueRetryApiResponse {
   prior_session?: RuntimeRetryPriorSessionApiResponse | null;
 }
 
-export interface RuntimeIssueApiResponse {
+export interface RuntimeIssueApiResponse extends RuntimeSnapshotMetaApiResponse {
   issue_identifier: string;
   issue_id: string | null;
   status: "running" | "retrying";
@@ -130,6 +134,14 @@ export interface RuntimeRefreshApiResponse {
   coalesced: boolean;
   requested_at: string;
   operations: string[];
+}
+
+export interface RuntimeInvalidationEvent {
+  sequence: number;
+  event: string;
+  emitted_at: string;
+  revision?: number;
+  issue_identifiers?: string[];
 }
 
 export interface RuntimeApiErrorEnvelope {
@@ -239,4 +251,11 @@ export interface RefreshReceiptViewModel {
   queuedLabel: string;
   requestedAt: string;
   operationsLabel: string;
+}
+
+export interface RuntimeLoadState<TSnapshot> {
+  snapshot: TSnapshot | null;
+  error: RuntimeUiError | null;
+  initialLoadPending: boolean;
+  refreshPending: boolean;
 }

--- a/apps/web/tests/runtime-session.service.test.ts
+++ b/apps/web/tests/runtime-session.service.test.ts
@@ -1,0 +1,498 @@
+import { DestroyRef } from "@angular/core";
+import { of, throwError } from "rxjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RuntimeApiService } from "../src/app/shared/api/runtime-api.service";
+import {
+  computeRuntimeRefreshDelay,
+  parseRuntimeInvalidationEvent,
+  RuntimeSessionService
+} from "../src/app/shared/api/runtime-session.service";
+import {
+  RefreshReceiptViewModel,
+  RuntimeIssueApiResponse,
+  RuntimeStateApiResponse
+} from "../src/app/shared/lib/runtime-types";
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Set<(event: Event) => void>>();
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const callback =
+      typeof listener === "function"
+        ? listener
+        : (event: Event) => listener.handleEvent(event);
+    const listeners = this.listeners.get(type) ?? new Set<(event: Event) => void>();
+    listeners.add(callback);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const listeners = this.listeners.get(type);
+    if (!listeners) {
+      return;
+    }
+    const callback =
+      typeof listener === "function"
+        ? listener
+        : (event: Event) => listener.handleEvent(event);
+    listeners.delete(callback);
+    if (listeners.size === 0) {
+      this.listeners.delete(type);
+    }
+  }
+
+  dispatch(type: string): void {
+    const listeners = this.listeners.get(type);
+    if (!listeners) {
+      return;
+    }
+    for (const listener of listeners) {
+      listener(new Event(type));
+    }
+  }
+}
+
+class FakeDocument extends FakeEventTarget {
+  visibilityState: DocumentVisibilityState = "visible";
+}
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  private readonly listeners = new Map<string, Set<(event: Event) => void>>();
+  closed = false;
+
+  constructor(readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    const callback =
+      typeof listener === "function"
+        ? listener
+        : (event: Event) => listener.handleEvent(event);
+    const listeners = this.listeners.get(type) ?? new Set<(event: Event) => void>();
+    listeners.add(callback);
+    this.listeners.set(type, listeners);
+  }
+
+  emit(type: string, payload: object): void {
+    const listeners = this.listeners.get(type);
+    if (!listeners) {
+      return;
+    }
+    const event = { data: JSON.stringify(payload) } as MessageEvent<string>;
+    for (const listener of listeners) {
+      listener(event);
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+}
+
+type TestDestroyRef = Pick<DestroyRef, "onDestroy"> & { destroy: () => void };
+
+type FakeRuntimeApi = {
+  loadStateSnapshot: ReturnType<typeof vi.fn>;
+  loadIssueSnapshot: ReturnType<typeof vi.fn>;
+  requestRefresh: ReturnType<typeof vi.fn>;
+};
+
+describe("RuntimeSessionService", () => {
+  let fakeWindow: FakeEventTarget;
+  let fakeDocument: FakeDocument;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-11T12:00:00Z"));
+    FakeEventSource.instances = [];
+    fakeWindow = new FakeEventTarget();
+    fakeDocument = new FakeDocument();
+    vi.stubGlobal("window", fakeWindow);
+    vi.stubGlobal("document", fakeDocument);
+    vi.stubGlobal("EventSource", FakeEventSource);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("computes the next refresh delay from expires_at", () => {
+    expect(
+      computeRuntimeRefreshDelay("2026-03-11T12:00:10Z")
+    ).toBe(10_000);
+    expect(computeRuntimeRefreshDelay("not-a-date")).toBe(5_000);
+  });
+
+  it("parses invalidation payloads and filters invalid identifiers", () => {
+    expect(
+      parseRuntimeInvalidationEvent(
+        JSON.stringify({
+          sequence: 3,
+          event: "issue_changed",
+          emitted_at: "2026-03-11T12:00:00Z",
+          revision: 7,
+          issue_identifiers: ["SYM-1", "", 42]
+        })
+      )
+    ).toEqual({
+      sequence: 3,
+      event: "issue_changed",
+      emitted_at: "2026-03-11T12:00:00Z",
+      revision: 7,
+      issue_identifiers: ["SYM-1"]
+    });
+    expect(parseRuntimeInvalidationEvent("bad json")).toBeNull();
+  });
+
+  it("loads state immediately and schedules the next refresh from expires_at", () => {
+    const api = createRuntimeApi({
+      stateSnapshots: [
+        makeStateSnapshot({ revision: 1, expiresAt: "2026-03-11T12:00:10Z" }),
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:00:25Z" })
+      ]
+    });
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const destroyRef = createDestroyRef();
+
+    const resource = service.watchState(destroyRef);
+
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(1);
+    expect(resource.loadState().snapshot?.revision).toBe(1);
+
+    vi.advanceTimersByTime(10_000);
+
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(2);
+    expect(resource.loadState().snapshot?.revision).toBe(2);
+
+    destroyRef.destroy();
+  });
+
+  it("refreshes active resources on focus recovery", () => {
+    const api = createRuntimeApi({
+      stateSnapshots: [
+        makeStateSnapshot({ revision: 1, expiresAt: "2026-03-11T12:10:00Z" }),
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:20:00Z" })
+      ]
+    });
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const destroyRef = createDestroyRef();
+
+    service.watchState(destroyRef);
+    fakeWindow.dispatch("focus");
+
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(2);
+
+    destroyRef.destroy();
+  });
+
+  it("refreshes active resources when the page becomes visible again", () => {
+    const api = createRuntimeApi({
+      stateSnapshots: [
+        makeStateSnapshot({ revision: 1, expiresAt: "2026-03-11T12:10:00Z" }),
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:20:00Z" })
+      ]
+    });
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const destroyRef = createDestroyRef();
+
+    service.watchState(destroyRef);
+
+    fakeDocument.visibilityState = "hidden";
+    fakeDocument.dispatch("visibilitychange");
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(1);
+
+    fakeDocument.visibilityState = "visible";
+    fakeDocument.dispatch("visibilitychange");
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(2);
+
+    destroyRef.destroy();
+  });
+
+  it("revalidates state only when SSE announces a newer revision", () => {
+    const api = createRuntimeApi({
+      stateSnapshots: [
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:10:00Z" }),
+        makeStateSnapshot({ revision: 3, expiresAt: "2026-03-11T12:20:00Z" })
+      ]
+    });
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const destroyRef = createDestroyRef();
+
+    service.watchState(destroyRef);
+    const eventSource = FakeEventSource.instances[0];
+
+    eventSource.emit("snapshot_updated", {
+      sequence: 1,
+      event: "snapshot_updated",
+      emitted_at: "2026-03-11T12:00:00Z",
+      revision: 2
+    });
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(1);
+
+    eventSource.emit("snapshot_updated", {
+      sequence: 2,
+      event: "snapshot_updated",
+      emitted_at: "2026-03-11T12:00:01Z",
+      revision: 3
+    });
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(2);
+
+    destroyRef.destroy();
+    expect(eventSource.closed).toBe(true);
+  });
+
+  it("refreshes active resources and reconnects when the SSE stream errors", () => {
+    const api = createRuntimeApi({
+      stateSnapshots: [
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:10:00Z" }),
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:10:00Z" }),
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:10:00Z" }),
+        makeStateSnapshot({ revision: 3, expiresAt: "2026-03-11T12:20:00Z" })
+      ]
+    });
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const destroyRef = createDestroyRef();
+
+    const resource = service.watchState(destroyRef);
+    const firstEventSource = FakeEventSource.instances[0];
+
+    firstEventSource.emit("error", {});
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(2);
+    expect(firstEventSource.closed).toBe(true);
+
+    vi.advanceTimersByTime(1_000);
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(3);
+    expect(FakeEventSource.instances).toHaveLength(2);
+
+    const secondEventSource = FakeEventSource.instances[1];
+    secondEventSource.emit("snapshot_updated", {
+      sequence: 2,
+      event: "snapshot_updated",
+      emitted_at: "2026-03-11T12:00:01Z",
+      revision: 3
+    });
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(4);
+    expect(resource.loadState().snapshot?.revision).toBe(3);
+
+    destroyRef.destroy();
+    expect(secondEventSource.closed).toBe(true);
+  });
+
+  it("recovers from failed refreshes and allows later triggers to fetch again", () => {
+    let loadCount = 0;
+    const api = {
+      loadStateSnapshot: vi.fn(() => {
+        loadCount += 1;
+        if (loadCount === 1) {
+          return of(makeStateSnapshot({ revision: 1, expiresAt: "2026-03-11T12:10:00Z" }));
+        }
+        if (loadCount === 2) {
+          return throwError(() => ({
+            kind: "http",
+            code: "unavailable",
+            message: "snapshot unavailable",
+            status: 503
+          }));
+        }
+        return of(makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:20:00Z" }));
+      }),
+      loadIssueSnapshot: vi.fn(),
+      requestRefresh: vi.fn(() =>
+        of({
+          queuedLabel: "Refresh request queued.",
+          requestedAt: "Mar 11, 2026, 12:00 PM",
+          operationsLabel: "poll + reconcile"
+        } satisfies RefreshReceiptViewModel)
+      )
+    };
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const destroyRef = createDestroyRef();
+    const resource = service.watchState(destroyRef);
+
+    fakeWindow.dispatch("focus");
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(2);
+    expect(resource.loadState().error?.message).toBe("snapshot unavailable");
+
+    fakeWindow.dispatch("focus");
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(3);
+    expect(resource.loadState().snapshot?.revision).toBe(2);
+    expect(resource.loadState().error).toBeNull();
+
+    destroyRef.destroy();
+  });
+
+  it("refreshes only matching issue resources for issue_changed events", () => {
+    const api = createRuntimeApi({
+      issueSnapshots: {
+        "SYM-1": [
+          makeIssueSnapshot({
+            identifier: "SYM-1",
+            revision: 1,
+            expiresAt: "2026-03-11T12:10:00Z"
+          })
+        ],
+        "SYM-2": [
+          makeIssueSnapshot({
+            identifier: "SYM-2",
+            revision: 1,
+            expiresAt: "2026-03-11T12:10:00Z"
+          }),
+          makeIssueSnapshot({
+            identifier: "SYM-2",
+            revision: 2,
+            expiresAt: "2026-03-11T12:20:00Z"
+          })
+        ]
+      }
+    });
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const issueOne = service.connectIssue("SYM-1");
+    const issueTwo = service.connectIssue("SYM-2");
+    const eventSource = FakeEventSource.instances[0];
+
+    expect(api.loadIssueSnapshot).toHaveBeenCalledTimes(2);
+
+    eventSource.emit("issue_changed", {
+      sequence: 1,
+      event: "issue_changed",
+      emitted_at: "2026-03-11T12:00:00Z",
+      revision: 2,
+      issue_identifiers: ["SYM-2"]
+    });
+
+    expect(api.loadIssueSnapshot).toHaveBeenCalledTimes(3);
+    expect(issueOne.loadState().snapshot?.revision).toBe(1);
+    expect(issueTwo.loadState().snapshot?.revision).toBe(2);
+
+    issueOne.destroy();
+    issueTwo.destroy();
+  });
+
+  it("requests a backend refresh and then revalidates active resources", () => {
+    const api = createRuntimeApi({
+      stateSnapshots: [
+        makeStateSnapshot({ revision: 1, expiresAt: "2026-03-11T12:10:00Z" }),
+        makeStateSnapshot({ revision: 2, expiresAt: "2026-03-11T12:20:00Z" })
+      ]
+    });
+    const service = new RuntimeSessionService(api as unknown as RuntimeApiService);
+    const destroyRef = createDestroyRef();
+
+    service.watchState(destroyRef);
+    let receipt: RefreshReceiptViewModel | null = null;
+    service.requestRefresh().subscribe((value) => {
+      receipt = value;
+    });
+
+    expect(api.requestRefresh).toHaveBeenCalledTimes(1);
+    expect(api.loadStateSnapshot).toHaveBeenCalledTimes(2);
+    expect(receipt?.queuedLabel).toBe("Refresh request queued.");
+
+    destroyRef.destroy();
+  });
+});
+
+function createRuntimeApi(input: {
+  stateSnapshots?: RuntimeStateApiResponse[];
+  issueSnapshots?: Record<string, RuntimeIssueApiResponse[]>;
+}): FakeRuntimeApi {
+  const stateSnapshots = [...(input.stateSnapshots ?? [])];
+  const issueSnapshots = new Map(
+    Object.entries(input.issueSnapshots ?? {}).map(([key, value]) => [key, [...value]])
+  );
+
+  return {
+    loadStateSnapshot: vi.fn(() => of(stateSnapshots.shift() ?? stateSnapshots.at(-1)!)),
+    loadIssueSnapshot: vi.fn((issueIdentifier: string) =>
+      of(
+        issueSnapshots.get(issueIdentifier)?.shift() ??
+          issueSnapshots.get(issueIdentifier)?.at(-1)!
+      )
+    ),
+    requestRefresh: vi.fn(() =>
+      of({
+        queuedLabel: "Refresh request queued.",
+        requestedAt: "Mar 11, 2026, 12:00 PM",
+        operationsLabel: "poll + reconcile"
+      } satisfies RefreshReceiptViewModel)
+    )
+  };
+}
+
+function createDestroyRef(): TestDestroyRef {
+  const callbacks: Array<() => void> = [];
+  return {
+    onDestroy(callback: () => void) {
+      callbacks.push(callback);
+    },
+    destroy() {
+      while (callbacks.length > 0) {
+        callbacks.pop()?.();
+      }
+    }
+  };
+}
+
+function makeStateSnapshot(input: {
+  revision: number;
+  expiresAt: string;
+}): RuntimeStateApiResponse {
+  return {
+    revision: input.revision,
+    generated_at: "2026-03-11T12:00:00Z",
+    expires_at: input.expiresAt,
+    counts: { running: 0, retrying: 0 },
+    running: [],
+    retrying: [],
+    codex_totals: {
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+      seconds_running: 0
+    },
+    rate_limits: null
+  };
+}
+
+function makeIssueSnapshot(input: {
+  identifier: string;
+  revision: number;
+  expiresAt: string;
+}): RuntimeIssueApiResponse {
+  return {
+    revision: input.revision,
+    generated_at: "2026-03-11T12:00:00Z",
+    expires_at: input.expiresAt,
+    issue_identifier: input.identifier,
+    issue_id: `${input.identifier}-id`,
+    status: "running",
+    workspace: { path: `/tmp/${input.identifier}` },
+    attempts: {
+      restart_count: 0,
+      current_retry_attempt: null
+    },
+    running: {
+      session_id: `${input.identifier}-session`,
+      turn_count: 1,
+      state: "In Progress",
+      started_at: "2026-03-11T11:59:00Z",
+      last_event: "notification",
+      last_message: "Working",
+      last_event_at: "2026-03-11T12:00:00Z",
+      tokens: {
+        input_tokens: 1,
+        output_tokens: 2,
+        total_tokens: 3
+      }
+    },
+    retry: null,
+    logs: { codex_session_logs: [] },
+    recent_events: [],
+    last_error: null,
+    tracked: {}
+  };
+}

--- a/docs/EXEC_PLAN_MIK-47.md
+++ b/docs/EXEC_PLAN_MIK-47.md
@@ -1,0 +1,128 @@
+# Add Backend-Driven Runtime Auto-Refresh for the Angular Dashboard
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This document must be maintained in accordance with `.agent/PLANS.md`.
+
+## Purpose / Big Picture
+
+After this change, an operator can leave the runtime dashboard or an issue detail page open and watch backend-owned runtime state update without manually reloading the browser. The backend remains the only authority for runtime state: the browser keeps reading canonical REST snapshots, while optional server-sent events (SSE) only act as lightweight invalidation nudges that trigger another REST fetch.
+
+The user-visible proof is straightforward. Start the runtime sidecar, open the Angular dashboard, let the orchestrator change runtime state, and observe running or retrying rows update on their own. Open an issue detail page for a running or retrying issue and observe its status-related fields refresh without a full page reload. Trigger `POST /api/v1/refresh` and observe the UI catch up automatically.
+
+## Progress
+
+- [x] 2026-03-11 11:35Z: Routed the ticket from `Todo` to `In Progress`, created the Linear workpad, and synced the repository from `origin/main`.
+- [x] 2026-03-11 11:42Z: Audited the current runtime fetch flow. Confirmed that Angular runtime pages use one-shot `HttpClient` requests with no shared polling, focus recovery, or `EventSource` handling.
+- [x] 2026-03-11 11:44Z: Audited the backend runtime surface. Confirmed that the orchestrator already republishes the snapshot on meaningful state changes and that `/api/v1/state`, `/api/v1/<issue_identifier>`, and `/api/v1/refresh` are the existing REST contracts.
+- [ ] Add monotonic snapshot revision metadata, issue-detail freshness metadata, and a lightweight SSE invalidation bus plus `/api/v1/events`.
+- [ ] Add a shared Angular runtime session service that owns polling, focus/visibility recovery, and SSE-triggered revalidation.
+- [ ] Rewire dashboard and issue detail to consume the shared runtime session service instead of owning fetch state directly.
+- [ ] Add focused backend and frontend tests plus docs for the refresh model and WSGI streaming tradeoff.
+
+## Surprises & Discoveries
+
+- Observation: the backend already refreshes the in-memory and on-disk runtime snapshot on every meaningful orchestrator transition, so the missing behavior is propagation to the browser rather than backend publication.
+  Evidence: `apps/api/symphony/orchestrator/core.py` calls `_refresh_runtime_snapshot()` from startup, dispatch, running-state reconciliation, retry scheduling, retry release, and heartbeat paths.
+
+- Observation: the issue detail endpoint currently omits snapshot freshness metadata even though dashboard state already exposes `generated_at` and `expires_at`.
+  Evidence: `apps/api/symphony/observability/runtime.py:get_runtime_issue_snapshot(...)` returns issue-specific details only, while `apps/api/symphony/api/views.py:runtime_issue(...)` forwards that object directly.
+
+- Observation: the current frontend has no reusable runtime data layer; dashboard and issue detail each own their own initial load and error state.
+  Evidence: `apps/web/src/app/features/dashboard/dashboard-page.component.ts` and `apps/web/src/app/features/issues/issue-detail-page.component.ts` both subscribe directly to `RuntimeApiService`.
+
+## Decision Log
+
+- Decision: keep REST snapshots as the canonical read contract and use SSE only for invalidation, never for full runtime payloads.
+  Rationale: this preserves backend authority, keeps the current API contract central, and matches the ticket’s architectural constraints.
+  Date/Author: 2026-03-11 / Codex
+
+- Decision: add a monotonic `revision` field to runtime snapshot responses and mirror snapshot freshness metadata onto issue-detail responses.
+  Rationale: the frontend needs a stable deduplication key and a consistent way to schedule the next refresh for both summary and issue-specific views.
+  Date/Author: 2026-03-11 / Codex
+
+- Decision: introduce one shared Angular runtime session service rather than embedding timers, browser lifecycle listeners, or `EventSource` instances in page components.
+  Rationale: the ticket explicitly rejects per-component unmanaged timers, and a root-provided service is the narrowest way to keep revalidation policy centralized.
+  Date/Author: 2026-03-11 / Codex
+
+## Outcomes & Retrospective
+
+Work is in progress. The implementation target is clear: backend publication is already present, but browser revalidation is not. The remaining risk is making freshness metadata, SSE invalidation, and Angular scheduling line up cleanly without weakening the existing REST semantics.
+
+## Context and Orientation
+
+The backend runtime sidecar lives under `apps/api/symphony/api/` and `apps/api/symphony/observability/`. `apps/api/symphony/api/views.py` defines the HTTP endpoints for the dashboard HTML view, runtime JSON state, issue detail JSON, and the manual refresh trigger. `apps/api/symphony/observability/runtime.py` loads and shapes runtime snapshot data for those views. `apps/api/symphony/orchestrator/core.py` is the scheduler loop that owns the live runtime state and republishes the snapshot whenever the runtime changes.
+
+The Angular frontend lives under `apps/web/src/app/`. `apps/web/src/app/shared/api/runtime-api.service.ts` is the current stateless transport layer. `apps/web/src/app/features/dashboard/dashboard-page.component.ts` and `apps/web/src/app/features/issues/issue-detail-page.component.ts` are the two runtime pages that currently fetch once and then stop. `apps/web/src/app/shared/lib/runtime-presenters.ts` maps raw REST payloads into display-oriented view models.
+
+A “runtime snapshot” in this repository is the backend-owned JSON representation of running issues, retrying issues, aggregate Codex totals, rate limits, and freshness timestamps. “Freshness metadata” means `generated_at`, `expires_at`, and the new monotonic `revision` field this task adds. “Invalidation” means a tiny backend-to-browser signal that tells the browser “re-fetch the REST snapshot now”; it does not carry the full runtime state itself.
+
+## Plan of Work
+
+Start by extending the backend snapshot contract. In `apps/api/symphony/orchestrator/core.py`, add a runtime revision counter that increments every time `_refresh_runtime_snapshot()` rebuilds the canonical snapshot. Include that `revision` in the `/api/v1/state` payload and pass the snapshot’s `generated_at`, `expires_at`, and `revision` through `get_runtime_issue_snapshot(...)` so issue detail responses can schedule their own refreshes with the same freshness window.
+
+Next, add a small invalidation event broker under `apps/api/symphony/observability/`. It should keep a short in-memory history of lightweight events and allow waiting for the next event after a given sequence number. Expose it through a new `/api/v1/events` endpoint in `apps/api/symphony/api/views.py` and `apps/api/config/urls.py` using Django `StreamingHttpResponse` with `text/event-stream`. This endpoint should publish only invalidation events such as `snapshot_updated`, `issue_changed`, and `refresh_queued`, with concise JSON payloads that include the latest snapshot revision and any directly relevant issue identifiers. Document clearly that each connected browser consumes one WSGI worker thread for the life of the stream, which is acceptable only for a small internal operator audience.
+
+Then add a shared Angular runtime session service, likely alongside `RuntimeApiService` in `apps/web/src/app/shared/api/`. This service should own one shared subscription to `/api/v1/state` plus keyed issue-detail resources. It should compute the next polling deadline from `expires_at`, trigger immediate revalidation on `visibilitychange` or `focus`, and optionally use a single `EventSource` connection to `/api/v1/events` to trigger early revalidation when the backend publishes an invalidation event. Page-local view concerns such as expanded dashboard cards stay in the components, but fetch lifecycle, polling, and SSE handling move into this shared service.
+
+Finally, rewire the runtime pages to consume the shared service and add tests. Backend tests should prove the new `revision` and issue freshness metadata, the refresh-queued invalidation path, and SSE event formatting or wait behavior. Frontend tests should prove that the shared runtime service polls from `expires_at`, reacts to focus or visibility recovery, deduplicates repeated invalidations by revision, and keeps dashboard plus issue detail pages updating from the same policy.
+
+## Concrete Steps
+
+Work from the repository root, `/Users/mike/code/symphony-workspaces/MIK-47`.
+
+Before editing backend code, review the existing runtime endpoints and snapshot builder:
+
+    rg -n "runtime_state|runtime_issue|runtime_refresh|_refresh_runtime_snapshot|_build_runtime_snapshot" apps/api
+
+Before editing frontend code, review the current one-shot fetch flow:
+
+    rg -n "loadDashboard|loadIssue|requestRefresh|constructor\\(|paramMap" apps/web/src/app
+
+During validation, run these commands from the repository root:
+
+    make lint
+    make typecheck
+    make test
+
+Run focused backend coverage while iterating:
+
+    uv run pytest apps/api/tests/unit/api/test_state.py apps/api/tests/unit/orchestrator/test_core.py -q
+
+Run focused frontend coverage while iterating:
+
+    pnpm --dir apps/web test -- --runInBand
+
+If a command fails because of unrelated inherited environment variables, sanitize the shell by unsetting `SYMPHONY_RUNTIME_*`, `SYMPHONY_WORKFLOW_PATH`, `LINEAR_API_KEY`, and `VIRTUAL_ENV` for the focused test invocation.
+
+## Validation and Acceptance
+
+Acceptance is behavioral. The dashboard should load once, then continue updating as backend state changes while the page remains open. Issue detail pages should do the same for the specific issue being viewed. The Angular code must use one shared refresh policy rather than page-specific timers.
+
+Run the backend and frontend test commands above and expect them to pass. Then exercise the runtime UI manually by starting the runtime sidecar, opening the dashboard, and causing a runtime state transition. The visible running or retrying counts should update without browser reload. Trigger `POST /api/v1/refresh` and observe a subsequent automatic refresh. If SSE is enabled in the final implementation, restart the runtime sidecar while the page is open and verify that the browser reconnects or falls back to polling without getting stuck on stale data.
+
+## Idempotence and Recovery
+
+The code changes in this plan are additive and can be applied incrementally. The SSE endpoint must tolerate clients disconnecting at any point. The Angular runtime session service must be safe to start and stop repeatedly as routes mount and unmount. If the SSE stream fails or the browser does not support `EventSource`, polling based on `expires_at` remains the fallback path, so the UI continues to converge to backend state.
+
+## Artifacts and Notes
+
+Current reproduction signal, captured before implementation:
+
+    apps/web/src/app/shared/api/runtime-api.service.ts only exposes cold REST reads.
+    apps/web/src/app/features/dashboard/dashboard-page.component.ts loads once in the constructor and reloads only after the manual Refresh button succeeds.
+    apps/web/src/app/features/issues/issue-detail-page.component.ts reloads only when the route parameter changes.
+    Repository search found no EventSource, visibilitychange, focus, or polling logic in apps/web/src/app.
+
+## Interfaces and Dependencies
+
+The backend should continue using Django’s built-in HTTP response primitives. The SSE endpoint should use `StreamingHttpResponse` with `text/event-stream`, `Cache-Control: no-cache`, and a small keepalive cadence so idle streams stay open through internal proxies.
+
+The backend invalidation broker should expose a small, testable API similar to:
+
+    publish_runtime_invalidation(event_type: str, payload: Mapping[str, Any]) -> dict[str, Any]
+    wait_for_runtime_invalidation(after_sequence: int | None, timeout_seconds: float) -> dict[str, Any] | None
+
+The Angular shared runtime service should remain built on the existing `RuntimeApiService` transport boundary and Angular signals. It should expose shared state and issue-detail resources, plus explicit methods for manual refresh and lifecycle attachment, while keeping `RuntimeApiService` responsible for HTTP transport and `toRuntimeUiError(...)` normalization.
+
+Plan revision note: 2026-03-11 11:45Z / Codex. Created this ticket-specific ExecPlan because `docs/EXEC_PLAN.md` currently tracks separate Plane tracker work and cannot be repurposed without losing the active plan for that effort.

--- a/docs/development.md
+++ b/docs/development.md
@@ -97,6 +97,29 @@ Health check: `GET http://127.0.0.1:8000/healthz` → `{"status":"ok","service":
 
 The runtime sidecar also exposes the dashboard JSON endpoints under `/api/v1/*`.
 
+### Runtime refresh model
+
+- The Angular runtime views treat the REST snapshot endpoints as the canonical
+  source of truth: `GET /api/v1/state`, `GET /api/v1/<issue_identifier>`, and
+  `POST /api/v1/refresh`.
+- Snapshot freshness metadata (`generated_at`, `expires_at`, `revision`) drives
+  automatic revalidation in the browser. The shared frontend runtime session
+  service schedules the next poll from `expires_at` instead of using a fixed
+  interval.
+- The browser also revalidates immediately when the page regains focus or
+  becomes visible again, so background tabs do not stay stale until the next
+  scheduled poll.
+- `GET /api/v1/events` is an optional SSE invalidation stream. Events are
+  lightweight signals such as `snapshot_updated`, `issue_changed`, and
+  `refresh_queued`; the browser reacts by fetching the canonical REST snapshot
+  again rather than trusting streamed state payloads.
+- The current runtime HTTP sidecar is a threaded WSGI server. Each connected
+  SSE client occupies one server thread for the life of the stream, so this
+  path is intended for a small number of internal operator sessions rather than
+  high fan-out traffic.
+- The invalidation broker is process-local in memory. SSE clients must connect
+  to the same runtime sidecar process that is publishing snapshot updates.
+
 ### Angular Frontend
 
 ```sh


### PR DESCRIPTION
## Summary
- add monotonic runtime snapshot revision metadata plus a lightweight SSE invalidation stream on the backend
- introduce a shared Angular runtime session service for polling, focus recovery, SSE invalidation handling, and stream-error recovery
- rewire the dashboard and issue detail pages onto the shared runtime refresh policy and document the WSGI/process-local SSE tradeoffs

## Validation
- make lint
- make typecheck
- make test
- uv run pytest apps/api/tests/unit/api/test_state.py apps/api/tests/unit/orchestrator/test_core.py -q
- pnpm --dir apps/web test -- tests/runtime-session.service.test.ts
- live validation against Django `:8010` + Angular `:4210` covering dashboard polling, issue-detail refresh, focus recovery, `POST /api/v1/refresh`, and sidecar restart recovery
