### PR TITLE
fix(web): remove duplicate labels and redundant fields on issue detai…

### DIFF
--- a/apps/web/src/app/features/issues/issue-detail-page.component.ts
+++ b/apps/web/src/app/features/issues/issue-detail-page.component.ts
@@ -80,7 +80,6 @@ type IssueState =
             <mat-card appearance="outlined">
               <mat-card-content>
                 <div class="identity-header">
-                  <h3 class="identity-title">{{ detail.identifier }}</h3>
                   <mat-chip-set>
                     <mat-chip class="chip-accent" disableRipple>{{
                       detail.statusLabel
@@ -116,9 +115,6 @@ type IssueState =
             <!-- Sessions grid -->
             <div class="sessions-grid">
               <mat-card appearance="outlined">
-                <mat-card-header>
-                  <mat-card-subtitle>Current session</mat-card-subtitle>
-                </mat-card-header>
                 <mat-card-content>
                   @if (detail.currentSession; as s) {
                     <app-session-summary [session]="s" />
@@ -129,9 +125,6 @@ type IssueState =
               </mat-card>
 
               <mat-card appearance="outlined">
-                <mat-card-header>
-                  <mat-card-subtitle>Last session summary</mat-card-subtitle>
-                </mat-card-header>
                 <mat-card-content>
                   @if (detail.previousSession; as s) {
                     <app-session-summary [session]="s" />
@@ -145,10 +138,7 @@ type IssueState =
             <!-- Events card -->
             <mat-card appearance="outlined">
               <mat-card-header>
-                <mat-card-subtitle>Recent events</mat-card-subtitle>
-                <mat-card-title>Recent activity</mat-card-title>
-                <span class="spacer"></span>
-                <a mat-button routerLink="/">Return to dashboard</a>
+                <mat-card-title>Recent events</mat-card-title>
               </mat-card-header>
               <mat-divider />
               <mat-card-content>
@@ -218,11 +208,7 @@ type IssueState =
         gap: 0.75rem;
         margin-bottom: 1rem;
       }
-      .identity-title {
-        font-size: 1.875rem;
-        font-weight: 600;
-        margin: 0;
-      }
+
       .detail-grid {
         display: grid;
         gap: 1rem 2rem;
@@ -262,9 +248,7 @@ type IssueState =
       }
 
       /* Events */
-      .spacer {
-        flex: 1;
-      }
+
       .event-item {
         padding: 1rem 0;
       }

--- a/apps/web/src/app/shared/lib/runtime-presenters.ts
+++ b/apps/web/src/app/shared/lib/runtime-presenters.ts
@@ -95,7 +95,7 @@ export function presentIssueSnapshot(
       : null,
     previousSession: snapshot.retry?.prior_session
       ? presentSessionSummary({
-          title: "Previous session",
+          title: "Last session",
           sessionId: snapshot.retry.prior_session.session_id,
           turnCount: snapshot.retry.prior_session.turn_count,
           lastEvent: snapshot.retry.prior_session.last_event,

--- a/apps/web/src/app/shared/ui/session-summary.component.ts
+++ b/apps/web/src/app/shared/ui/session-summary.component.ts
@@ -25,9 +25,9 @@ import { IssueSessionSummaryViewModel } from "../lib/runtime-types";
   styles: [
     `
       .session-title {
-        font-size: 1.5rem;
+        font-size: 1.125rem;
         font-weight: 600;
-        margin: 0.5rem 0 0;
+        margin: 0 0 0.25rem;
       }
       mat-list {
         padding: 0;


### PR DESCRIPTION
…l page

- Remove duplicate identifier heading from identity card (already shown in page header)
- Remove redundant card subtitles from session cards (session-summary component renders its own title)
- Collapse double events card headers ('Recent events' + 'Recent activity') into single title
- Remove duplicate 'Return to dashboard' button from events card (page header already has one)
- Clean up unused .identity-title and .spacer CSS rules
- Unify previous session title wording to 'Last session'
- Adjust session-summary title font size for standalone use