### PR TITLE
MIK-37: Implement Plane payload normalization and HTTP transport primitives

### DIFF
--- a/apps/api/symphony/tracker/__init__.py
+++ b/apps/api/symphony/tracker/__init__.py
@@ -21,6 +21,16 @@ from .linear_client import (
     LinearTransportResponse,
 )
 from .models import Issue, IssueBlocker
+from .plane import PlanePayloadError, normalize_plane_issue
+from .plane_client import (
+    PlaneAPIError,
+    PlaneAPIRequestError,
+    PlaneAPIStatusError,
+    PlaneIssuePage,
+    PlaneTrackerClient,
+    PlaneTransportResponse,
+    build_plane_issue_collection_url,
+)
 from .write_contract import (
     TrackerAttachment,
     TrackerComment,
@@ -68,6 +78,13 @@ __all__ = [
     "LinearPayloadError",
     "LinearTrackerClient",
     "LinearTransportResponse",
+    "PlaneAPIError",
+    "PlaneAPIRequestError",
+    "PlaneAPIStatusError",
+    "PlaneIssuePage",
+    "PlanePayloadError",
+    "PlaneTrackerClient",
+    "PlaneTransportResponse",
     "TrackerMutationBackend",
     "TrackerAttachment",
     "TrackerComment",
@@ -91,8 +108,10 @@ __all__ = [
     "TrackerValidationError",
     "TrackerWorkflowState",
     "UPDATE_ISSUE_STATE_MUTATION",
+    "build_plane_issue_collection_url",
     "build_tracker_mutation_backend",
     "build_tracker_read_client",
     "build_tracker_mutation_service",
     "normalize_linear_issue",
+    "normalize_plane_issue",
 ]

--- a/apps/api/symphony/tracker/plane.py
+++ b/apps/api/symphony/tracker/plane.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime
+from typing import Any
+
+from .models import Issue, IssueBlocker
+
+
+class PlanePayloadError(Exception):
+    code = "plane_unknown_payload"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+_PLANE_PRIORITY_MAP = {
+    "urgent": 1,
+    "high": 2,
+    "medium": 3,
+    "normal": 3,
+    "low": 4,
+}
+
+
+def normalize_plane_issue(
+    payload: Mapping[str, Any],
+    *,
+    project_identifier: str | None = None,
+) -> Issue:
+    issue_id = _require_string(payload, "id")
+    sequence_id = _require_sequence_id(payload)
+    title = _extract_title(payload)
+    state = _extract_state_name(payload)
+    if state is None:
+        raise PlanePayloadError("Plane issue payload is missing state.name.")
+
+    resolved_project_identifier = project_identifier or _extract_project_identifier(payload)
+    if resolved_project_identifier is None:
+        raise PlanePayloadError("Plane issue payload is missing project.identifier.")
+
+    return Issue(
+        id=issue_id,
+        identifier=f"{resolved_project_identifier}-{sequence_id}",
+        title=title,
+        description=_extract_description(payload),
+        priority=_normalize_priority(payload.get("priority")),
+        state=state,
+        branch_name=_extract_branch_name(payload),
+        url=_optional_string(payload.get("url")),
+        labels=_normalize_labels(payload.get("labels")),
+        blocked_by=_normalize_blocked_by(payload),
+        created_at=_parse_timestamp(payload.get("created_at") or payload.get("createdAt")),
+        updated_at=_parse_timestamp(payload.get("updated_at") or payload.get("updatedAt")),
+    )
+
+
+def _require_string(payload: Mapping[str, Any], key: str) -> str:
+    value = _optional_string(payload.get(key))
+    if value is None:
+        raise PlanePayloadError(f"Plane issue payload is missing {key}.")
+    return value
+
+
+def _require_sequence_id(payload: Mapping[str, Any]) -> str:
+    sequence_id = _optional_identifier(payload.get("sequence_id") or payload.get("sequenceId"))
+    if sequence_id is None:
+        raise PlanePayloadError("Plane issue payload is missing sequence_id.")
+    return sequence_id
+
+
+def _extract_title(payload: Mapping[str, Any]) -> str:
+    title = _optional_string(payload.get("name") or payload.get("title"))
+    if title is None:
+        raise PlanePayloadError("Plane issue payload is missing name.")
+    return title
+
+
+def _extract_description(payload: Mapping[str, Any]) -> str | None:
+    return _optional_string(
+        payload.get("description_stripped")
+        or payload.get("descriptionStripped")
+        or payload.get("description_text")
+        or payload.get("description")
+    )
+
+
+def _extract_branch_name(payload: Mapping[str, Any]) -> str | None:
+    return _optional_string(
+        payload.get("branch_name")
+        or payload.get("branchName")
+        or payload.get("github_branch_name")
+        or payload.get("githubBranchName")
+    )
+
+
+def _extract_state_name(payload: Mapping[str, Any]) -> str | None:
+    state_value = payload.get("state") or payload.get("state_detail") or payload.get("stateDetail")
+    if isinstance(state_value, Mapping):
+        return _optional_string(state_value.get("name"))
+    return _optional_string(payload.get("state_name") or payload.get("stateName") or state_value)
+
+
+def _extract_project_identifier(payload: Mapping[str, Any]) -> str | None:
+    project_value = (
+        payload.get("project")
+        or payload.get("project_detail")
+        or payload.get("projectDetail")
+        or payload.get("project_identifier")
+        or payload.get("projectIdentifier")
+    )
+    if isinstance(project_value, Mapping):
+        return _optional_string(project_value.get("identifier"))
+    return _optional_string(project_value)
+
+
+def _normalize_priority(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if not normalized or normalized in {"none", "no priority"}:
+            return None
+        if normalized.isdigit():
+            return int(normalized)
+        return _PLANE_PRIORITY_MAP.get(normalized)
+    return None
+
+
+def _normalize_labels(value: Any) -> tuple[str, ...]:
+    normalized_labels: list[str] = []
+    for node in _iter_nodes(value):
+        if isinstance(node, str):
+            label_name = _optional_string(node)
+        elif isinstance(node, Mapping):
+            label_name = _optional_string(node.get("name"))
+        else:
+            label_name = None
+
+        if label_name is not None:
+            normalized_labels.append(label_name.lower())
+
+    return tuple(normalized_labels)
+
+
+def _normalize_blocked_by(payload: Mapping[str, Any]) -> tuple[IssueBlocker, ...]:
+    raw_blockers = (
+        payload.get("blocked_by")
+        or payload.get("blockedBy")
+        or payload.get("blocked_by_issues")
+        or payload.get("blockedByIssues")
+    )
+    blockers: list[IssueBlocker] = []
+
+    for blocker_value in _iter_nodes(raw_blockers):
+        blocker_payload = _extract_related_issue(blocker_value)
+        if blocker_payload is None:
+            continue
+
+        blockers.append(
+            IssueBlocker(
+                id=_optional_string(blocker_payload.get("id")),
+                identifier=_extract_blocker_identifier(blocker_payload),
+                state=_extract_state_name(blocker_payload),
+            )
+        )
+
+    return tuple(blockers)
+
+
+def _extract_related_issue(value: Any) -> Mapping[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+
+    nested_issue = value.get("issue") or value.get("related_issue") or value.get("relatedIssue")
+    if isinstance(nested_issue, Mapping):
+        return nested_issue
+    return value
+
+
+def _extract_blocker_identifier(payload: Mapping[str, Any]) -> str | None:
+    explicit_identifier = _optional_string(payload.get("identifier"))
+    if explicit_identifier is not None:
+        return explicit_identifier
+
+    project_identifier = _extract_project_identifier(payload)
+    sequence_id = _optional_identifier(payload.get("sequence_id") or payload.get("sequenceId"))
+    if project_identifier is None or sequence_id is None:
+        return None
+    return f"{project_identifier}-{sequence_id}"
+
+
+def _optional_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _optional_identifier(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    return _optional_string(value)
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    raw_value = _optional_string(value)
+    if raw_value is None:
+        return None
+
+    candidate = raw_value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(candidate)
+    except ValueError as exc:
+        raise PlanePayloadError(f"Plane issue payload has invalid timestamp: {raw_value}.") from exc
+
+
+def _iter_nodes(value: Any) -> Iterable[Any]:
+    if isinstance(value, Mapping):
+        for key in ("results", "nodes"):
+            nodes = value.get(key)
+            if isinstance(nodes, list):
+                return nodes
+        return ()
+    if isinstance(value, list):
+        return value
+    return ()

--- a/apps/api/symphony/tracker/plane_client.py
+++ b/apps/api/symphony/tracker/plane_client.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs, quote, urlencode, urlparse
+from urllib.request import Request, urlopen
+
+from symphony.workflow.config import PlaneTrackerConfig
+
+from .plane import PlanePayloadError
+
+DEFAULT_PLANE_TIMEOUT_MS = 30_000
+DEFAULT_PLANE_PAGE_SIZE = 50
+PLANE_ISSUES_PATH_TEMPLATE = "/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/"
+
+
+class PlaneAPIError(Exception):
+    code = "plane_api_error"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class PlaneAPIRequestError(PlaneAPIError):
+    code = "plane_api_request"
+
+
+class PlaneAPIStatusError(PlaneAPIError):
+    code = "plane_api_status"
+
+
+@dataclass(slots=True, frozen=True)
+class PlaneTransportResponse:
+    status_code: int
+    body: str
+
+
+class PlaneTransport(Protocol):
+    def __call__(
+        self,
+        *,
+        url: str,
+        headers: Mapping[str, str],
+        query_params: Mapping[str, object],
+        timeout_ms: int,
+    ) -> PlaneTransportResponse: ...
+
+
+@dataclass(slots=True, frozen=True)
+class PlaneIssuePage:
+    items: tuple[Mapping[str, Any], ...]
+    next_offset: int | None
+    count: int | None
+
+
+@dataclass(slots=True)
+class PlaneTrackerClient:
+    tracker_config: PlaneTrackerConfig
+    timeout_ms: int = DEFAULT_PLANE_TIMEOUT_MS
+    transport: PlaneTransport | None = None
+
+    def fetch_issue_page(
+        self,
+        *,
+        limit: int = DEFAULT_PLANE_PAGE_SIZE,
+        offset: int = 0,
+        query_params: Mapping[str, object] | None = None,
+    ) -> PlaneIssuePage:
+        payload = self._fetch_json(
+            path=PLANE_ISSUES_PATH_TEMPLATE.format(
+                workspace_slug=quote(self.tracker_config.workspace_slug or "", safe=""),
+                project_id=quote(self.tracker_config.project_id or "", safe=""),
+            ),
+            query_params={
+                "limit": limit,
+                "offset": offset,
+                **(dict(query_params) if query_params is not None else {}),
+            },
+        )
+        return _extract_issue_page(payload)
+
+    def build_issue_collection_url(self) -> str:
+        return build_plane_issue_collection_url(self.tracker_config)
+
+    def _fetch_json(
+        self,
+        *,
+        path: str,
+        query_params: Mapping[str, object],
+    ) -> Mapping[str, Any]:
+        transport = self.transport or _default_plane_transport
+        response = self._send_request(
+            transport=transport,
+            path=path,
+            query_params=query_params,
+        )
+        return _decode_payload(response)
+
+    def _send_request(
+        self,
+        *,
+        transport: PlaneTransport,
+        path: str,
+        query_params: Mapping[str, object],
+    ) -> PlaneTransportResponse:
+        try:
+            response = transport(
+                url=_join_base_url(self.tracker_config.api_base_url or "", path),
+                headers={
+                    "Accept": "application/json",
+                    "X-API-Key": self.tracker_config.api_key or "",
+                },
+                query_params=query_params,
+                timeout_ms=self.timeout_ms,
+            )
+        except PlaneAPIError:
+            raise
+        except Exception as exc:
+            raise PlaneAPIRequestError("Plane API request failed.") from exc
+
+        if response.status_code < 200 or response.status_code >= 300:
+            raise PlaneAPIStatusError(f"Plane API responded with HTTP {response.status_code}.")
+
+        return response
+
+
+def build_plane_issue_collection_url(tracker_config: PlaneTrackerConfig) -> str:
+    return _join_base_url(
+        tracker_config.api_base_url or "",
+        PLANE_ISSUES_PATH_TEMPLATE.format(
+            workspace_slug=quote(tracker_config.workspace_slug or "", safe=""),
+            project_id=quote(tracker_config.project_id or "", safe=""),
+        ),
+    )
+
+
+def _default_plane_transport(
+    *,
+    url: str,
+    headers: Mapping[str, str],
+    query_params: Mapping[str, object],
+    timeout_ms: int,
+) -> PlaneTransportResponse:
+    request_url = _append_query_params(url, query_params)
+    request = Request(request_url, headers=dict(headers), method="GET")
+
+    try:
+        with urlopen(request, timeout=timeout_ms / 1000) as response:
+            body = response.read().decode("utf-8")
+            return PlaneTransportResponse(status_code=response.status, body=body)
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        return PlaneTransportResponse(status_code=exc.code, body=body)
+    except (URLError, OSError) as exc:
+        raise PlaneAPIRequestError("Plane API request failed.") from exc
+
+
+def _join_base_url(base_url: str, path: str) -> str:
+    normalized_base_url = (base_url or "").rstrip("/")
+    return f"{normalized_base_url}{path}"
+
+
+def _append_query_params(url: str, query_params: Mapping[str, object]) -> str:
+    encoded_query = urlencode(_normalize_query_params(query_params), doseq=True)
+    if not encoded_query:
+        return url
+    return f"{url}?{encoded_query}"
+
+
+def _normalize_query_params(query_params: Mapping[str, object]) -> list[tuple[str, str]]:
+    normalized: list[tuple[str, str]] = []
+    for key, value in query_params.items():
+        if value is None:
+            continue
+        if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+            for item in value:
+                normalized_item = _normalize_query_param_value(key, item)
+                if normalized_item is not None:
+                    normalized.append((key, normalized_item))
+            continue
+
+        normalized_value = _normalize_query_param_value(key, value)
+        if normalized_value is not None:
+            normalized.append((key, normalized_value))
+
+    return normalized
+
+
+def _normalize_query_param_value(key: str, value: object) -> str | None:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized:
+            return normalized
+        return None
+
+    raise PlaneAPIRequestError(f"Plane request contains malformed query parameter: {key}.")
+
+
+def _decode_payload(response: PlaneTransportResponse) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(response.body)
+    except json.JSONDecodeError as exc:
+        raise PlanePayloadError("Plane response body must be valid JSON.") from exc
+
+    if not isinstance(payload, Mapping):
+        raise PlanePayloadError("Plane response body must be a JSON object.")
+
+    return payload
+
+
+def _extract_issue_page(payload: Mapping[str, Any]) -> PlaneIssuePage:
+    results = payload.get("results")
+    if not isinstance(results, list):
+        raise PlanePayloadError("Plane issue response is missing results.")
+
+    normalized_results: list[Mapping[str, Any]] = []
+    for result in results:
+        if not isinstance(result, Mapping):
+            raise PlanePayloadError("Plane issue response contains a malformed result.")
+        normalized_results.append(result)
+
+    count = payload.get("count")
+    if count is not None and (isinstance(count, bool) or not isinstance(count, int) or count < 0):
+        raise PlanePayloadError("Plane issue response contains a malformed count.")
+
+    return PlaneIssuePage(
+        items=tuple(normalized_results),
+        next_offset=_extract_next_offset(payload.get("next")),
+        count=count,
+    )
+
+
+def _extract_next_offset(value: Any) -> int | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise PlanePayloadError("Plane issue response contains a malformed next page URL.")
+
+    parsed = urlparse(value)
+    query = parse_qs(parsed.query)
+    offsets = query.get("offset")
+    if not offsets or not offsets[0]:
+        raise PlanePayloadError("Plane issue response next page URL is missing offset.")
+
+    try:
+        next_offset = int(offsets[0])
+    except ValueError as exc:
+        raise PlanePayloadError(
+            "Plane issue response next page URL contains an invalid offset."
+        ) from exc
+
+    if next_offset < 0:
+        raise PlanePayloadError("Plane issue response next page URL contains an invalid offset.")
+
+    return next_offset

--- a/apps/api/tests/unit/tracker/test_plane.py
+++ b/apps/api/tests/unit/tracker/test_plane.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from symphony.tracker import IssueBlocker, PlanePayloadError, normalize_plane_issue
+
+
+def test_normalize_plane_issue_normalizes_full_issue_payload() -> None:
+    issue = normalize_plane_issue(
+        {
+            "id": "issue-1",
+            "sequence_id": 123,
+            "name": "Normalize Plane payloads",
+            "description_stripped": "Implement tracker normalization",
+            "priority": "high",
+            "state": {"name": "Todo"},
+            "branch_name": "feature/eng-123",
+            "url": "https://plane.example/engineering/issues/123",
+            "project": {"identifier": "ENG"},
+            "labels": [
+                {"name": "Backend"},
+                {"name": "Needs Review"},
+            ],
+            "blocked_by": [
+                {
+                    "id": "issue-2",
+                    "sequence_id": 99,
+                    "project": {"identifier": "ENG"},
+                    "state": {"name": "In Progress"},
+                }
+            ],
+            "created_at": "2026-03-01T12:00:00Z",
+            "updated_at": "2026-03-02T15:30:00Z",
+        }
+    )
+
+    assert issue.id == "issue-1"
+    assert issue.identifier == "ENG-123"
+    assert issue.title == "Normalize Plane payloads"
+    assert issue.description == "Implement tracker normalization"
+    assert issue.priority == 2
+    assert issue.state == "Todo"
+    assert issue.branch_name == "feature/eng-123"
+    assert issue.url == "https://plane.example/engineering/issues/123"
+    assert issue.labels == ("backend", "needs review")
+    assert issue.blocked_by == (
+        IssueBlocker(
+            id="issue-2",
+            identifier="ENG-99",
+            state="In Progress",
+        ),
+    )
+    assert issue.created_at == datetime(2026, 3, 1, 12, 0, tzinfo=UTC)
+    assert issue.updated_at == datetime(2026, 3, 2, 15, 30, tzinfo=UTC)
+
+
+def test_normalize_plane_issue_accepts_project_identifier_override() -> None:
+    issue = normalize_plane_issue(
+        {
+            "id": "issue-7",
+            "sequenceId": "44",
+            "title": "Use project override",
+            "state_name": "In Progress",
+            "labels": {"results": [{"name": "Ops"}]},
+        },
+        project_identifier="OPS",
+    )
+
+    assert issue.identifier == "OPS-44"
+    assert issue.title == "Use project override"
+    assert issue.labels == ("ops",)
+
+
+def test_normalize_plane_issue_accepts_missing_optional_fields() -> None:
+    issue = normalize_plane_issue(
+        {
+            "id": "issue-8",
+            "sequence_id": 8,
+            "name": "Minimal payload",
+            "state": {"name": "Todo"},
+            "project": {"identifier": "ENG"},
+        }
+    )
+
+    assert issue.description is None
+    assert issue.priority is None
+    assert issue.branch_name is None
+    assert issue.url is None
+    assert issue.labels == ()
+    assert issue.blocked_by == ()
+    assert issue.created_at is None
+    assert issue.updated_at is None
+
+
+def test_normalize_plane_issue_maps_named_priorities_and_blank_values() -> None:
+    high = normalize_plane_issue(
+        {
+            "id": "issue-high",
+            "sequence_id": 9,
+            "name": "Priority high",
+            "priority": "urgent",
+            "state": {"name": "Todo"},
+            "project": {"identifier": "ENG"},
+        }
+    )
+    none = normalize_plane_issue(
+        {
+            "id": "issue-none",
+            "sequence_id": 10,
+            "name": "Priority none",
+            "priority": "none",
+            "state": {"name": "Todo"},
+            "project": {"identifier": "ENG"},
+        }
+    )
+
+    assert high.priority == 1
+    assert none.priority is None
+
+
+@pytest.mark.parametrize("missing_key", ["id", "name", "sequence_id"])
+def test_normalize_plane_issue_requires_core_fields(missing_key: str) -> None:
+    payload = {
+        "id": "issue-1",
+        "sequence_id": 12,
+        "name": "Required fields",
+        "state": {"name": "Todo"},
+        "project": {"identifier": "ENG"},
+    }
+    del payload[missing_key]
+
+    with pytest.raises(PlanePayloadError, match=missing_key):
+        normalize_plane_issue(payload)
+
+
+def test_normalize_plane_issue_requires_state_name() -> None:
+    with pytest.raises(PlanePayloadError, match="state.name"):
+        normalize_plane_issue(
+            {
+                "id": "issue-1",
+                "sequence_id": 12,
+                "name": "Missing state",
+                "project": {"identifier": "ENG"},
+            }
+        )
+
+
+def test_normalize_plane_issue_requires_project_identifier() -> None:
+    with pytest.raises(PlanePayloadError, match="project.identifier"):
+        normalize_plane_issue(
+            {
+                "id": "issue-1",
+                "sequence_id": 12,
+                "name": "Missing project",
+                "state": {"name": "Todo"},
+            }
+        )
+
+
+def test_normalize_plane_issue_rejects_invalid_timestamps() -> None:
+    with pytest.raises(PlanePayloadError, match="invalid timestamp"):
+        normalize_plane_issue(
+            {
+                "id": "issue-1",
+                "sequence_id": 12,
+                "name": "Bad timestamps",
+                "state": {"name": "Todo"},
+                "project": {"identifier": "ENG"},
+                "created_at": "not-a-timestamp",
+            }
+        )

--- a/apps/api/tests/unit/tracker/test_plane_client.py
+++ b/apps/api/tests/unit/tracker/test_plane_client.py
@@ -1,14 +1,195 @@
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
+from typing import Any
+
 import pytest
-
-pytestmark = pytest.mark.skip(
-    reason=(
-        "Plane tracker client tests land with the Plane-backed write adapter; "
-        "MIK-40 only neutralizes the generic write contract."
-    )
+from symphony.tracker import (
+    PlaneAPIRequestError,
+    PlaneAPIStatusError,
+    PlanePayloadError,
+    PlaneTrackerClient,
+    PlaneTransportResponse,
+    build_plane_issue_collection_url,
 )
+from symphony.tracker.plane_client import DEFAULT_PLANE_PAGE_SIZE
+from symphony.workflow.config import PlaneTrackerConfig
 
 
-def test_plane_client_placeholder_for_milestone_4_validation_command() -> None:
-    pass
+class RecordingTransport:
+    def __init__(
+        self,
+        *,
+        response: PlaneTransportResponse | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.response = response
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        *,
+        url: str,
+        headers: Mapping[str, str],
+        query_params: Mapping[str, object],
+        timeout_ms: int,
+    ) -> PlaneTransportResponse:
+        self.calls.append(
+            {
+                "url": url,
+                "headers": dict(headers),
+                "query_params": dict(query_params),
+                "timeout_ms": timeout_ms,
+            }
+        )
+
+        if self.error is not None:
+            raise self.error
+        if self.response is None:
+            raise AssertionError("Test transport expected a configured response.")
+        return self.response
+
+
+def make_tracker_config() -> PlaneTrackerConfig:
+    return PlaneTrackerConfig(
+        kind="plane",
+        api_base_url="https://plane.example/self-hosted",
+        api_key="plane-token",
+        workspace_slug="engineering",
+        project_id="project-123",
+        active_states=("Todo", "In Progress"),
+        terminal_states=("Done",),
+    )
+
+
+def test_build_plane_issue_collection_url_preserves_base_subpath_and_quotes_segments() -> None:
+    config = PlaneTrackerConfig(
+        kind="plane",
+        api_base_url="https://plane.example/root",
+        api_key="plane-token",
+        workspace_slug="engineering team",
+        project_id="project/123",
+        active_states=("Todo",),
+        terminal_states=("Done",),
+    )
+
+    url = build_plane_issue_collection_url(config)
+
+    assert (
+        url
+        == "https://plane.example/root/api/v1/workspaces/engineering%20team/projects/project%2F123/issues/"
+    )
+
+
+def test_fetch_issue_page_sends_auth_headers_and_parses_next_offset() -> None:
+    transport = RecordingTransport(
+        response=PlaneTransportResponse(
+            status_code=200,
+            body=json.dumps(
+                {
+                    "count": 1,
+                    "next": (
+                        "https://plane.example/self-hosted/api/v1/workspaces/engineering/"
+                        "projects/project-123/issues/?limit=50&offset=50"
+                    ),
+                    "results": [
+                        {
+                            "id": "issue-1",
+                            "name": "Dispatch candidate",
+                        }
+                    ],
+                }
+            ),
+        )
+    )
+    client = PlaneTrackerClient(make_tracker_config(), transport=transport)
+
+    page = client.fetch_issue_page(
+        query_params={
+            "expand": ["state", "labels", "project"],
+            "state": ["state-1", "state-2"],
+        }
+    )
+
+    assert page.count == 1
+    assert page.next_offset == 50
+    assert page.items == ({"id": "issue-1", "name": "Dispatch candidate"},)
+    assert len(transport.calls) == 1
+    assert (
+        transport.calls[0]["url"]
+        == "https://plane.example/self-hosted/api/v1/workspaces/engineering/projects/project-123/issues/"
+    )
+    assert transport.calls[0]["headers"] == {
+        "Accept": "application/json",
+        "X-API-Key": "plane-token",
+    }
+    assert transport.calls[0]["query_params"] == {
+        "limit": DEFAULT_PLANE_PAGE_SIZE,
+        "offset": 0,
+        "expand": ["state", "labels", "project"],
+        "state": ["state-1", "state-2"],
+    }
+    assert transport.calls[0]["timeout_ms"] == 30_000
+
+
+def test_fetch_issue_page_allows_final_page_without_next_link() -> None:
+    client = PlaneTrackerClient(
+        make_tracker_config(),
+        transport=RecordingTransport(
+            response=PlaneTransportResponse(
+                status_code=200,
+                body=json.dumps({"count": 1, "next": None, "results": [{"id": "issue-1"}]}),
+            )
+        ),
+    )
+
+    page = client.fetch_issue_page()
+
+    assert page.next_offset is None
+
+
+def test_fetch_issue_page_maps_transport_failures_to_typed_error() -> None:
+    client = PlaneTrackerClient(
+        make_tracker_config(),
+        transport=RecordingTransport(error=OSError("network down")),
+    )
+
+    with pytest.raises(PlaneAPIRequestError, match="Plane API request failed."):
+        client.fetch_issue_page()
+
+
+def test_fetch_issue_page_maps_non_2xx_status_to_typed_error() -> None:
+    client = PlaneTrackerClient(
+        make_tracker_config(),
+        transport=RecordingTransport(
+            response=PlaneTransportResponse(status_code=503, body='{"error":"bad gateway"}')
+        ),
+    )
+
+    with pytest.raises(PlaneAPIStatusError, match="HTTP 503"):
+        client.fetch_issue_page()
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "not-json",
+        json.dumps([]),
+        json.dumps({"count": 1}),
+        json.dumps({"results": ["bad-node"]}),
+        json.dumps({"results": [], "count": "1"}),
+        json.dumps({"results": [], "next": "https://plane.example/issues/?limit=50"}),
+    ],
+)
+def test_fetch_issue_page_maps_malformed_payloads_to_typed_error(body: str) -> None:
+    client = PlaneTrackerClient(
+        make_tracker_config(),
+        transport=RecordingTransport(
+            response=PlaneTransportResponse(status_code=200, body=body),
+        ),
+    )
+
+    with pytest.raises(PlanePayloadError):
+        client.fetch_issue_page()

--- a/apps/web/src/app/features/dashboard/dashboard-page.component.ts
+++ b/apps/web/src/app/features/dashboard/dashboard-page.component.ts
@@ -485,7 +485,9 @@ type RefreshState =
 export class DashboardPageComponent {
   private readonly runtimeSession = inject(RuntimeSessionService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly runtimeState = this.runtimeSession.watchState(this.destroyRef);
+  private readonly runtimeState = this.runtimeSession.watchState(
+    this.destroyRef
+  );
 
   readonly expandedIssues = signal(new Set<string>());
   readonly refreshState = signal<RefreshState>({ kind: "idle" });

--- a/apps/web/src/app/features/issues/issue-detail-page.component.ts
+++ b/apps/web/src/app/features/issues/issue-detail-page.component.ts
@@ -292,15 +292,17 @@ export class IssueDetailPageComponent {
     null;
 
   readonly issueIdentifier = signal("unknown");
-  readonly issueResource = signal<RuntimeResourceConnection<RuntimeIssueApiResponse> | null>(
-    null
+  readonly issueResource =
+    signal<RuntimeResourceConnection<RuntimeIssueApiResponse> | null>(null);
+  readonly issueLoadState = computed(
+    () =>
+      this.issueResource()?.loadState() ?? {
+        snapshot: null,
+        error: null,
+        initialLoadPending: true,
+        refreshPending: false
+      }
   );
-  readonly issueLoadState = computed(() => this.issueResource()?.loadState() ?? {
-    snapshot: null,
-    error: null,
-    initialLoadPending: true,
-    refreshPending: false
-  });
   readonly state = computed<IssueState>(() => {
     const loadState = this.issueLoadState();
     if (loadState.initialLoadPending && loadState.snapshot === null) {
@@ -345,7 +347,8 @@ export class IssueDetailPageComponent {
         const identifier = params.get("id") ?? "unknown";
         this.issueIdentifier.set(identifier);
         this.currentIssueResource?.destroy();
-        this.currentIssueResource = this.runtimeSession.connectIssue(identifier);
+        this.currentIssueResource =
+          this.runtimeSession.connectIssue(identifier);
         this.issueResource.set(this.currentIssueResource);
       });
   }

--- a/apps/web/src/app/shared/api/runtime-api.service.ts
+++ b/apps/web/src/app/shared/api/runtime-api.service.ts
@@ -27,22 +27,28 @@ export class RuntimeApiService {
   loadStateSnapshot(): Observable<RuntimeStateApiResponse> {
     return this.http
       .get<RuntimeStateApiResponse>("/api/v1/state")
-      .pipe(catchError((error: unknown) => throwError(() => toRuntimeUiError(error))));
+      .pipe(
+        catchError((error: unknown) =>
+          throwError(() => toRuntimeUiError(error))
+        )
+      );
   }
 
   loadDashboard(): Observable<DashboardViewModel> {
     return this.loadStateSnapshot().pipe(
-      map((response) => presentDashboardSnapshot(response)),
+      map((response) => presentDashboardSnapshot(response))
     );
   }
 
   loadRuns(): Observable<RunsViewModel> {
     return this.loadStateSnapshot().pipe(
-      map((response) => presentRunsSnapshot(response)),
+      map((response) => presentRunsSnapshot(response))
     );
   }
 
-  loadIssueSnapshot(issueIdentifier: string): Observable<RuntimeIssueApiResponse> {
+  loadIssueSnapshot(
+    issueIdentifier: string
+  ): Observable<RuntimeIssueApiResponse> {
     return this.http
       .get<RuntimeIssueApiResponse>(
         `/api/v1/${encodeURIComponent(issueIdentifier)}`

--- a/apps/web/src/app/shared/api/runtime-session.service.ts
+++ b/apps/web/src/app/shared/api/runtime-session.service.ts
@@ -1,4 +1,10 @@
-import { DestroyRef, Injectable, Signal, WritableSignal, signal } from "@angular/core";
+import {
+  DestroyRef,
+  Injectable,
+  Signal,
+  WritableSignal,
+  signal
+} from "@angular/core";
 import { Observable, Subscription, tap } from "rxjs";
 
 import { RuntimeApiService } from "./runtime-api.service";
@@ -27,7 +33,9 @@ type RuntimeManagedResource<TSnapshot extends RuntimeManagedSnapshot> = {
   refreshQueued: boolean;
 };
 
-export interface RuntimeResourceHandle<TSnapshot extends RuntimeManagedSnapshot> {
+export interface RuntimeResourceHandle<
+  TSnapshot extends RuntimeManagedSnapshot
+> {
   loadState: Signal<RuntimeLoadState<TSnapshot>>;
   refresh: () => void;
 }
@@ -62,12 +70,11 @@ export class RuntimeSessionService {
   private readonly eventErrorListener = () => this.handleEventStreamError();
   private browserListenersActive = false;
   private eventSource: EventSource | null = null;
-  private eventSourceReconnectHandle: ReturnType<typeof globalThis.setTimeout> | null =
-    null;
+  private eventSourceReconnectHandle: ReturnType<
+    typeof globalThis.setTimeout
+  > | null = null;
 
-  constructor(
-    private readonly api: RuntimeApiService
-  ) {
+  constructor(private readonly api: RuntimeApiService) {
     this.stateResource = this.createResource("state", () =>
       this.api.loadStateSnapshot()
     );
@@ -93,13 +100,14 @@ export class RuntimeSessionService {
   ): RuntimeResourceConnection<RuntimeIssueApiResponse> {
     const existingResource = this.issueResources.get(issueIdentifier);
     const resource =
-      existingResource ??
-      this.createIssueResource(issueIdentifier);
+      existingResource ?? this.createIssueResource(issueIdentifier);
     return this.connectResource(resource);
   }
 
   requestRefresh(): Observable<RefreshReceiptViewModel> {
-    return this.api.requestRefresh().pipe(tap(() => this.refreshActiveResources()));
+    return this.api
+      .requestRefresh()
+      .pipe(tap(() => this.refreshActiveResources()));
   }
 
   private createIssueResource(
@@ -330,16 +338,26 @@ export class RuntimeSessionService {
   private handleInvalidation(event: RuntimeInvalidationEvent): void {
     const issueIdentifiers = event.issue_identifiers ?? [];
     const revision = typeof event.revision === "number" ? event.revision : null;
-    const stateRevision = getSnapshotRevision(this.stateResource.loadState().snapshot);
+    const stateRevision = getSnapshotRevision(
+      this.stateResource.loadState().snapshot
+    );
 
-    if (this.stateResource.watchCount > 0 && shouldRefreshForRevision(stateRevision, revision)) {
+    if (
+      this.stateResource.watchCount > 0 &&
+      shouldRefreshForRevision(stateRevision, revision)
+    ) {
       this.fetchResource(this.stateResource);
     }
 
     if (issueIdentifiers.length === 0) {
       for (const resource of this.issueResources.values()) {
-        const issueRevision = getSnapshotRevision(resource.loadState().snapshot);
-        if (resource.watchCount > 0 && shouldRefreshForRevision(issueRevision, revision)) {
+        const issueRevision = getSnapshotRevision(
+          resource.loadState().snapshot
+        );
+        if (
+          resource.watchCount > 0 &&
+          shouldRefreshForRevision(issueRevision, revision)
+        ) {
           this.fetchResource(resource);
         }
       }
@@ -412,7 +430,8 @@ export function parseRuntimeInvalidationEvent(
         typeof parsed.revision === "number" ? parsed.revision : undefined,
       issue_identifiers: Array.isArray(parsed.issue_identifiers)
         ? parsed.issue_identifiers.filter(
-            (value): value is string => typeof value === "string" && value.length > 0
+            (value): value is string =>
+              typeof value === "string" && value.length > 0
           )
         : undefined
     };

--- a/docs/EXEC_PLAN.md
+++ b/docs/EXEC_PLAN.md
@@ -17,6 +17,8 @@ The most important outcome is architectural, not cosmetic. The repository must s
 - [x] 2026-03-11 03:22Z: Replaced the completed roadmap closeout plan with this new active ExecPlan focused on Plane integration and tracker abstraction.
 - [x] 2026-03-11 05:14Z: Completed Milestone 1. Added `apps/api/symphony/tracker/interfaces.py` and `apps/api/symphony/tracker/factory.py`, routed `apps/api/symphony/orchestrator/core.py` and `apps/api/symphony/tracker/write_service.py` through those shared seams, and added focused tests for the new factory path.
 - [x] 2026-03-11 05:14Z: Validated Milestone 1 in a sanitized shell environment that unsets inherited `LINEAR_API_KEY`, `SYMPHONY_RUNTIME_*`, `SYMPHONY_WORKFLOW_PATH`, and `VIRTUAL_ENV` exports. Evidence: pre-change baseline `114 passed in 4.12s`; post-change milestone suite `107 passed in 4.15s`; focused factory tests `2 passed in 0.04s`; combined regression check `109 passed in 4.12s`; `uv run ruff check ...` and `uv run mypy apps/api` both passed.
+- [x] 2026-03-12 01:04Z: Landed the `MIK-37` Plane read-foundation slice. Added `apps/api/symphony/tracker/plane.py` to normalize representative Plane issue payloads into the shared `Issue` model, added `apps/api/symphony/tracker/plane_client.py` with deterministic authenticated REST helpers for self-hosted Plane issue-list reads, and replaced the Plane tracker test placeholder with focused unit coverage.
+- [x] 2026-03-12 01:04Z: Validated the `MIK-37` slice with `uv run ruff check apps/api/symphony/tracker/plane.py apps/api/symphony/tracker/plane_client.py apps/api/symphony/tracker/__init__.py apps/api/tests/unit/tracker/test_plane.py apps/api/tests/unit/tracker/test_plane_client.py`, `uv run mypy apps/api`, and `uv run pytest apps/api/tests/unit/tracker/test_plane.py apps/api/tests/unit/tracker/test_plane_client.py -q`. Evidence: `ruff check` passed, `mypy` reported `Success: no issues found in 83 source files`, and the focused Plane suite reported `21 passed in 0.50s`.
 - [ ] Extend workflow configuration and validation so `tracker.kind: plane` is a first-class typed configuration with self-host-friendly fields.
 - [ ] Add a Plane adapter for issue reads, issue normalization, issue comments, issue state transitions, and pull request link attachment.
 - [ ] Update tests, docs, and operator-facing examples so the repository describes a pluggable tracker system instead of a Linear-only system.
@@ -37,6 +39,9 @@ The most important outcome is architectural, not cosmetic. The repository must s
 
 - Observation: the focused Milestone 1 pytest baselines are sensitive to inherited shell exports from another live Symphony workspace, even before tracker refactor code changes.
   Evidence: running the documented pre-change suite in the inherited shell failed with `16 failed, 98 passed in 3.60s` because `LINEAR_API_KEY` changed workflow-config expectations and `SYMPHONY_RUNTIME_*` plus `SYMPHONY_WORKFLOW_PATH` pointed at another workspace’s live runtime files; rerunning the exact suite with those variables unset passed with `114 passed in 4.12s`.
+
+- Observation: Plane’s public API docs now emphasize `/work-items/` endpoints and mark `/issues/` endpoints deprecated with a sunset date of 2026-03-31, while the current ticket sequence still targets `/issues/`-shaped issue reads.
+  Evidence: the official Plane API reference consulted on 2026-03-12 documents `work-items` as the primary surface and labels the older `issues` endpoints deprecated. The `MIK-37` slice therefore kept the issue-list path isolated to one tracker-local template so a future migration does not leak endpoint assumptions into orchestrator code.
 
 ## Decision Log
 
@@ -59,6 +64,10 @@ The most important outcome is architectural, not cosmetic. The repository must s
 - Decision: Preserve the runtime snapshot and Angular API response shapes for issue execution state unless a Plane requirement forces a change.
   Rationale: the runtime UI is already tracker-neutral enough. Changing it during the adapter refactor would expand the scope without helping the main integration goal.
   Date/Author: 2026-03-11 / Codex
+
+- Decision: Keep the `MIK-37` work at the adapter-foundation layer and avoid enabling Plane in the tracker factory or orchestrator until the higher-level read adapter lands.
+  Rationale: this ticket only needs payload normalization plus deterministic HTTP primitives. Deferring factory wiring keeps the scope bounded, avoids semantic changes in orchestrator code, and leaves a single migration point if the repository switches from `/issues/` to `/work-items/`.
+  Date/Author: 2026-03-12 / Codex
 
 ## Outcomes & Retrospective
 


### PR DESCRIPTION
## Summary
- add Plane issue payload normalization into the shared tracker `Issue` model
- add deterministic self-hosted Plane REST transport helpers for authenticated issue-list reads
- replace the Plane tracker test placeholder with focused normalization and transport coverage

## Validation
- uv run ruff check apps/api/symphony/tracker/plane.py apps/api/symphony/tracker/plane_client.py apps/api/symphony/tracker/__init__.py apps/api/tests/unit/tracker/test_plane.py apps/api/tests/unit/tracker/test_plane_client.py
- uv run mypy apps/api
- uv run pytest apps/api/tests/unit/tracker/test_plane.py apps/api/tests/unit/tracker/test_plane_client.py -q