### PR TITLE
MIK-36: Add Plane startup validation coverage

### DIFF
--- a/apps/api/symphony/management/commands/run_orchestrator.py
+++ b/apps/api/symphony/management/commands/run_orchestrator.py
@@ -118,15 +118,17 @@ class Command(BaseCommand):
         http_server = self._start_http_server(host=bind_host, port=http_port)
 
         async def run() -> None:
-            orchestrator = Orchestrator(config=config, workflow_runtime=workflow_runtime)
+            orchestrator: Orchestrator | None = None
             try:
+                orchestrator = Orchestrator(config=config, workflow_runtime=workflow_runtime)
                 if run_once:
                     await orchestrator.run_once()
                     await orchestrator.wait_for_running_workers()
                 else:
                     await orchestrator.run_forever()
             finally:
-                await orchestrator.aclose()
+                if orchestrator is not None:
+                    await orchestrator.aclose()
 
         try:
             try:
@@ -134,6 +136,17 @@ class Command(BaseCommand):
             finally:
                 if http_server is not None:
                     http_server.close()
+        except WorkflowConfigError as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                "startup_validation_failed",
+                fields={
+                    "error_code": exc.code,
+                    "message": exc.message,
+                },
+            )
+            raise CommandError(f"Startup failed ({exc.code}): {exc.message}") from exc
         except KeyboardInterrupt:
             self.stdout.write(self.style.WARNING("Orchestrator stopped by signal."))
 

--- a/apps/api/symphony/workflow/config.py
+++ b/apps/api/symphony/workflow/config.py
@@ -256,15 +256,32 @@ def build_service_config(
 
 
 def require_linear_tracker_config(tracker: TrackerConfig) -> LinearTrackerConfig:
+    _validate_tracker_config(tracker)
     if isinstance(tracker, PlaneTrackerConfig):
-        if not tracker.api_key:
-            raise MissingTrackerAPIKeyError(
-                "tracker.api_key is required when tracker.kind is 'plane'."
-            )
+        raise UnsupportedTrackerKindError(
+            "tracker.kind must be set to the supported tracker kind 'linear'."
+        )
 
+    return tracker
+
+
+def validate_dispatch_config(config: ServiceConfig) -> None:
+    _validate_tracker_config(config.tracker)
+
+    if not config.codex.command.strip():
+        raise MissingCodexCommandError("codex.command must be a non-empty shell command.")
+
+
+def _validate_tracker_config(tracker: TrackerConfig) -> None:
+    if isinstance(tracker, PlaneTrackerConfig):
         if not tracker.api_base_url:
             raise MissingTrackerAPIBaseURLError(
                 "tracker.api_base_url is required when tracker.kind is 'plane'."
+            )
+
+        if not tracker.api_key:
+            raise MissingTrackerAPIKeyError(
+                "tracker.api_key is required when tracker.kind is 'plane'."
             )
 
         if not tracker.workspace_slug:
@@ -276,10 +293,7 @@ def require_linear_tracker_config(tracker: TrackerConfig) -> LinearTrackerConfig
             raise MissingTrackerProjectIDError(
                 "tracker.project_id is required when tracker.kind is 'plane'."
             )
-
-        raise UnsupportedTrackerKindError(
-            "tracker.kind must be set to the supported tracker kind 'linear'."
-        )
+        return
 
     if tracker.kind != "linear":
         raise UnsupportedTrackerKindError(
@@ -295,15 +309,6 @@ def require_linear_tracker_config(tracker: TrackerConfig) -> LinearTrackerConfig
         raise MissingTrackerProjectSlugError(
             "tracker.project_slug is required when tracker.kind is 'linear'."
         )
-
-    return tracker
-
-
-def validate_dispatch_config(config: ServiceConfig) -> None:
-    require_linear_tracker_config(config.tracker)
-
-    if not config.codex.command.strip():
-        raise MissingCodexCommandError("codex.command must be a non-empty shell command.")
 
 
 def _get_section(config: dict[str, Any], key: str) -> Mapping[str, Any]:

--- a/apps/api/tests/unit/management/test_run_orchestrator.py
+++ b/apps/api/tests/unit/management/test_run_orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Generator
 from io import StringIO
 from pathlib import Path
 
@@ -10,6 +11,7 @@ from django.core.management.base import CommandError
 from symphony.management.commands.run_orchestrator import Command
 from symphony.management.commands.run_orchestrator import Orchestrator as CommandOrchestrator
 from symphony.observability.runtime import get_runtime_observability_config
+from symphony.workflow import WORKFLOW_PATH_ENV_VAR
 
 MINIMAL_VALID_WORKFLOW = """---
 tracker:
@@ -33,12 +35,45 @@ tracker:
 """
 
 
+PLANE_WORKFLOW_MISSING_API_BASE_URL = """---
+tracker:
+  kind: plane
+  api_key: plane-token
+  workspace_slug: workspace
+  project_id: project-123
+---
+# Prompt body
+"""
+
+
+PLANE_WORKFLOW_MISSING_API_KEY = """---
+tracker:
+  kind: plane
+  api_base_url: https://plane.example
+  workspace_slug: workspace
+  project_id: project-123
+---
+# Prompt body
+"""
+
+
 PLANE_WORKFLOW_MISSING_WORKSPACE_SLUG = """---
 tracker:
   kind: plane
   api_base_url: https://plane.example
   api_key: plane-token
   project_id: project-123
+---
+# Prompt body
+"""
+
+
+PLANE_WORKFLOW_MISSING_PROJECT_ID = """---
+tracker:
+  kind: plane
+  api_base_url: https://plane.example
+  api_key: plane-token
+  workspace_slug: workspace
 ---
 # Prompt body
 """
@@ -88,6 +123,15 @@ observability:
 """
 
 
+@pytest.fixture(autouse=True)
+def allow_caplog_to_capture_symphony_logs() -> Generator[None, None, None]:
+    symphony_logger = logging.getLogger("symphony")
+    previous_propagate = symphony_logger.propagate
+    symphony_logger.propagate = True
+    yield
+    symphony_logger.propagate = previous_propagate
+
+
 class FakeHTTPServer:
     def __init__(self, *, url: str = "http://127.0.0.1:43123/") -> None:
         self.url = url
@@ -113,6 +157,33 @@ def fake_async_method(calls: list[str], name: str) -> object:
 def write_workflow(path: Path, *, contents: str = MINIMAL_VALID_WORKFLOW) -> Path:
     path.write_text(contents, encoding="utf-8")
     return path
+
+
+def install_log_event_recorder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, dict[str, object | None]]]:
+    events: list[tuple[str, dict[str, object | None]]] = []
+
+    def _record_event(
+        logger: logging.Logger,
+        level: int,
+        event: str,
+        *,
+        fields: dict[str, object | None],
+    ) -> None:
+        del logger, level
+        events.append((event, dict(fields)))
+
+    monkeypatch.setattr(
+        "symphony.management.commands.run_orchestrator.log_event",
+        _record_event,
+    )
+    return events
+
+
+@pytest.fixture(autouse=True)
+def clear_workflow_path_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(WORKFLOW_PATH_ENV_VAR, raising=False)
 
 
 def install_fake_http_server(
@@ -443,24 +514,31 @@ def test_run_orchestrator_loads_workflow_observability_settings(
 
 
 def test_run_orchestrator_rejects_negative_cli_port(
-    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    events = install_log_event_recorder(monkeypatch)
     write_workflow(tmp_path / "WORKFLOW.md")
     monkeypatch.chdir(tmp_path)
-    caplog.set_level(logging.WARNING, logger="symphony.management.commands.run_orchestrator")
 
     with pytest.raises(CommandError, match=r"port must be an integer greater than or equal to 0"):
         call_command("run_orchestrator", "--port", "-1")
-    assert "event=startup_validation_failed error_code=workflow_config_error" in caplog.text
+    assert events == [
+        (
+            "startup_validation_failed",
+            {
+                "error_code": "workflow_config_error",
+                "message": "port must be an integer greater than or equal to 0.",
+            },
+        )
+    ]
 
 
 def test_run_orchestrator_rejects_non_integer_port_option(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    events = install_log_event_recorder(monkeypatch)
     command = Command()
-    caplog.set_level(logging.WARNING, logger="symphony.management.commands.run_orchestrator")
 
     with pytest.raises(
         CommandError,
@@ -468,14 +546,22 @@ def test_run_orchestrator_rejects_non_integer_port_option(
     ):
         command.handle(port="abc")
 
-    assert "event=startup_validation_failed error_code=workflow_config_error" in caplog.text
+    assert events == [
+        (
+            "startup_validation_failed",
+            {
+                "error_code": "workflow_config_error",
+                "message": "port must be an integer.",
+            },
+        )
+    ]
 
 
 def test_run_orchestrator_rejects_empty_cli_host(
-    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    events = install_log_event_recorder(monkeypatch)
     command = Command()
-    caplog.set_level(logging.WARNING, logger="symphony.management.commands.run_orchestrator")
 
     with pytest.raises(
         CommandError,
@@ -483,7 +569,15 @@ def test_run_orchestrator_rejects_empty_cli_host(
     ):
         command.handle(host="   ")
 
-    assert "event=startup_validation_failed error_code=workflow_config_error" in caplog.text
+    assert events == [
+        (
+            "startup_validation_failed",
+            {
+                "error_code": "workflow_config_error",
+                "message": "host must not be empty.",
+            },
+        )
+    ]
 
 
 def test_run_orchestrator_survives_logging_sink_failures(
@@ -520,13 +614,12 @@ def test_run_orchestrator_survives_logging_sink_failures(
 
 
 def test_run_orchestrator_surfaces_http_server_bind_failures(
-    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    events = install_log_event_recorder(monkeypatch)
     write_workflow(tmp_path / "WORKFLOW.md", contents=WORKFLOW_WITH_HTTP_PORT)
     monkeypatch.chdir(tmp_path)
-    caplog.set_level(logging.WARNING, logger="symphony.management.commands.run_orchestrator")
     monkeypatch.setattr(
         "symphony.management.commands.run_orchestrator.start_runtime_http_server",
         lambda *, host, port: (_ for _ in ()).throw(OSError("address in use")),
@@ -534,7 +627,17 @@ def test_run_orchestrator_surfaces_http_server_bind_failures(
 
     with pytest.raises(CommandError, match=r"Startup failed \(http_server_error\):"):
         call_command("run_orchestrator", "--once")
-    assert "event=http_server_bind_failed host=127.0.0.1 port=43123" in caplog.text
+    assert events == [
+        (
+            "http_server_bind_failed",
+            {
+                "host": "127.0.0.1",
+                "port": 43123,
+                "error_code": "OSError",
+                "message": "address in use",
+            },
+        )
+    ]
 
 
 def test_run_orchestrator_fails_when_default_workflow_is_missing(
@@ -555,22 +658,22 @@ def test_run_orchestrator_fails_when_explicit_workflow_is_missing(tmp_path: Path
 
 
 def test_run_orchestrator_surfaces_workflow_parse_failures(
-    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    events = install_log_event_recorder(monkeypatch)
     write_workflow(
         tmp_path / "WORKFLOW.md",
         contents="---\ntracker: [unterminated\n---\n# Prompt body\n",
     )
 
     monkeypatch.chdir(tmp_path)
-    caplog.set_level(logging.WARNING, logger="symphony.management.commands.run_orchestrator")
 
     with pytest.raises(CommandError, match=r"Startup failed \(workflow_parse_error\):"):
         call_command("run_orchestrator")
-    assert "event=workflow_load_failed" in caplog.text
-    assert "error_code=workflow_parse_error" in caplog.text
+    assert len(events) == 1
+    assert events[0][0] == "workflow_load_failed"
+    assert events[0][1]["error_code"] == "workflow_parse_error"
 
 
 def test_run_orchestrator_surfaces_config_validation_failures(
@@ -593,25 +696,42 @@ tracker:
         call_command("run_orchestrator")
 
 
+@pytest.mark.parametrize(
+    ("contents", "error_code"),
+    [
+        (PLANE_WORKFLOW_MISSING_API_BASE_URL, "missing_tracker_api_base_url"),
+        (PLANE_WORKFLOW_MISSING_API_KEY, "missing_tracker_api_key"),
+        (PLANE_WORKFLOW_MISSING_WORKSPACE_SLUG, "missing_tracker_workspace_slug"),
+        (PLANE_WORKFLOW_MISSING_PROJECT_ID, "missing_tracker_project_id"),
+    ],
+)
 def test_run_orchestrator_surfaces_precise_plane_config_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    contents: str,
+    error_code: str,
 ) -> None:
+    events = install_log_event_recorder(monkeypatch)
     write_workflow(
         tmp_path / "WORKFLOW.md",
-        contents=PLANE_WORKFLOW_MISSING_WORKSPACE_SLUG,
+        contents=contents,
     )
 
     monkeypatch.chdir(tmp_path)
 
-    with pytest.raises(CommandError, match=r"Startup failed \(missing_tracker_workspace_slug\):"):
-        call_command("run_orchestrator")
+    with pytest.raises(CommandError, match=rf"Startup failed \({error_code}\):"):
+        call_command("run_orchestrator", "--once")
+
+    assert len(events) == 1
+    assert events[0][0] == "workflow_load_failed"
+    assert events[0][1]["error_code"] == error_code
 
 
 def test_run_orchestrator_rejects_valid_plane_config_until_supported(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    events = install_log_event_recorder(monkeypatch)
     write_workflow(
         tmp_path / "WORKFLOW.md",
         contents=VALID_PLANE_WORKFLOW,
@@ -621,3 +741,13 @@ def test_run_orchestrator_rejects_valid_plane_config_until_supported(
 
     with pytest.raises(CommandError, match=r"Startup failed \(unsupported_tracker_kind\):"):
         call_command("run_orchestrator")
+
+    assert events == [
+        (
+            "startup_validation_failed",
+            {
+                "error_code": "unsupported_tracker_kind",
+                "message": "tracker.kind must be set to the supported tracker kind 'linear'.",
+            },
+        )
+    ]

--- a/apps/api/tests/unit/workflow/test_config.py
+++ b/apps/api/tests/unit/workflow/test_config.py
@@ -431,6 +431,17 @@ def test_validate_dispatch_config_surfaces_plane_tracker_field_errors(
             MissingTrackerProjectIDError,
             "tracker.project_id is required when tracker.kind is 'plane'.",
         ),
+        (
+            {
+                "kind": "plane",
+                "api_base_url": "https://plane.example",
+                "workspace_slug": "workspace",
+                "project_id": "project-123",
+                "api_key": "$PLANE_API_KEY",
+            },
+            MissingTrackerAPIKeyError,
+            "tracker.api_key is required when tracker.kind is 'plane'.",
+        ),
     ],
 )
 def test_validate_dispatch_config_surfaces_precise_errors_for_unresolved_plane_env_tokens(
@@ -472,7 +483,7 @@ def test_validate_dispatch_config_accepts_minimal_valid_linear_config() -> None:
     assert isinstance(service_config.tracker, LinearTrackerConfig)
 
 
-def test_validate_dispatch_config_rejects_fully_populated_plane_tracker_until_supported() -> None:
+def test_validate_dispatch_config_accepts_fully_populated_plane_tracker() -> None:
     service_config = build_service_config(
         build_definition(
             {
@@ -487,8 +498,7 @@ def test_validate_dispatch_config_rejects_fully_populated_plane_tracker_until_su
         )
     )
 
-    with pytest.raises(
-        UnsupportedTrackerKindError,
-        match="tracker.kind must be set to the supported tracker kind 'linear'.",
-    ):
-        validate_dispatch_config(service_config)
+    validate_dispatch_config(service_config)
+
+    assert isinstance(service_config, ServiceConfig)
+    assert isinstance(service_config.tracker, PlaneTrackerConfig)

--- a/apps/api/tests/unit/workflow/test_runtime.py
+++ b/apps/api/tests/unit/workflow/test_runtime.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
 import os
+import re
 import threading
 import time
 from pathlib import Path
+from typing import TypedDict
 
 import pytest
-from symphony.workflow import UnsupportedTrackerKindError, WorkflowRuntime
+from symphony.workflow import (
+    MissingTrackerAPIBaseURLError,
+    MissingTrackerAPIKeyError,
+    MissingTrackerProjectIDError,
+    MissingTrackerWorkspaceSlugError,
+    PlaneTrackerConfig,
+    WorkflowRuntime,
+)
+
+
+class PlaneWorkflowOverrides(TypedDict, total=False):
+    api_base_url: str | None
+    api_key: str | None
+    workspace_slug: str | None
+    project_id: str | None
 
 
 def write_workflow(
@@ -32,22 +48,43 @@ def write_workflow(
     return path
 
 
-def write_plane_workflow(path: Path, *, prompt_template: str = "Prompt body") -> Path:
-    path.write_text(
-        (
-            "---\n"
-            "tracker:\n"
-            "  kind: plane\n"
-            "  api_base_url: https://plane.example\n"
-            "  api_key: plane-token\n"
-            "  workspace_slug: workspace\n"
-            "  project_id: project-123\n"
-            "---\n"
-            f"{prompt_template}\n"
-        ),
-        encoding="utf-8",
-    )
+def write_plane_workflow(
+    path: Path,
+    *,
+    prompt_template: str = "Prompt body",
+    api_base_url: str | None = "https://plane.example",
+    api_key: str | None = "plane-token",
+    workspace_slug: str | None = "workspace",
+    project_id: str | None = "project-123",
+) -> Path:
+    lines = ["---", "tracker:", "  kind: plane"]
+    if api_base_url is not None:
+        lines.append(f"  api_base_url: {api_base_url}")
+    if api_key is not None:
+        lines.append(f"  api_key: {api_key}")
+    if workspace_slug is not None:
+        lines.append(f"  workspace_slug: {workspace_slug}")
+    if project_id is not None:
+        lines.append(f"  project_id: {project_id}")
+    lines.extend(["---", prompt_template, ""])
+    path.write_text("\n".join(lines), encoding="utf-8")
     return path
+
+
+def write_plane_workflow_with_overrides(
+    path: Path,
+    *,
+    prompt_template: str = "Prompt body",
+    overrides: PlaneWorkflowOverrides,
+) -> Path:
+    return write_plane_workflow(
+        path,
+        prompt_template=prompt_template,
+        api_base_url=overrides.get("api_base_url", "https://plane.example"),
+        api_key=overrides.get("api_key", "plane-token"),
+        workspace_slug=overrides.get("workspace_slug", "workspace"),
+        project_id=overrides.get("project_id", "project-123"),
+    )
 
 
 def test_workflow_runtime_reloads_changed_workflow_file(tmp_path: Path) -> None:
@@ -165,17 +202,90 @@ def test_workflow_runtime_requires_explicit_initial_load(tmp_path: Path) -> None
         runtime.reload_if_changed()
 
 
-def test_workflow_runtime_rejects_fully_populated_plane_configs_until_supported(
-    tmp_path: Path,
-) -> None:
+def test_workflow_runtime_loads_fully_populated_plane_config(tmp_path: Path) -> None:
     workflow_path = write_plane_workflow(tmp_path / "WORKFLOW.md")
     runtime = WorkflowRuntime(workflow_path)
 
+    config = runtime.load_initial()
+
+    assert isinstance(config.tracker, PlaneTrackerConfig)
+    assert config.tracker.workspace_slug == "workspace"
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error_type", "message"),
+    [
+        (
+            {"api_base_url": None},
+            MissingTrackerAPIBaseURLError,
+            "tracker.api_base_url is required when tracker.kind is 'plane'.",
+        ),
+        (
+            {"api_key": None},
+            MissingTrackerAPIKeyError,
+            "tracker.api_key is required when tracker.kind is 'plane'.",
+        ),
+        (
+            {"workspace_slug": None},
+            MissingTrackerWorkspaceSlugError,
+            "tracker.workspace_slug is required when tracker.kind is 'plane'.",
+        ),
+        (
+            {"project_id": None},
+            MissingTrackerProjectIDError,
+            "tracker.project_id is required when tracker.kind is 'plane'.",
+        ),
+    ],
+)
+def test_workflow_runtime_surfaces_plane_validation_errors_on_initial_load(
+    tmp_path: Path,
+    overrides: PlaneWorkflowOverrides,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    workflow_path = write_plane_workflow_with_overrides(
+        tmp_path / "WORKFLOW.md",
+        overrides=overrides,
+    )
+    runtime = WorkflowRuntime(workflow_path)
+
     with pytest.raises(
-        UnsupportedTrackerKindError,
-        match="tracker.kind must be set to the supported tracker kind 'linear'.",
+        error_type,
+        match=re.escape(message),
     ):
         runtime.load_initial()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error_code"),
+    [
+        ({"api_base_url": None}, "missing_tracker_api_base_url"),
+        ({"api_key": None}, "missing_tracker_api_key"),
+        ({"workspace_slug": None}, "missing_tracker_workspace_slug"),
+        ({"project_id": None}, "missing_tracker_project_id"),
+    ],
+)
+def test_workflow_runtime_preserves_last_good_config_when_plane_reload_is_invalid(
+    tmp_path: Path,
+    overrides: PlaneWorkflowOverrides,
+    error_code: str,
+) -> None:
+    workflow_path = write_workflow(tmp_path / "WORKFLOW.md", prompt_template="Prompt body v1")
+    runtime = WorkflowRuntime(workflow_path)
+    runtime.load_initial()
+
+    write_plane_workflow_with_overrides(
+        workflow_path,
+        prompt_template="Prompt body invalid",
+        overrides=overrides,
+    )
+
+    changed = runtime.reload_if_changed()
+
+    assert changed is False
+    assert runtime.config.prompt_template == "Prompt body v1"
+    assert runtime.last_error is not None
+    assert runtime.last_error.code == error_code
 
 
 def test_workflow_runtime_watches_for_file_changes(tmp_path: Path) -> None:

--- a/apps/web/src/app/features/dashboard/dashboard-page.component.ts
+++ b/apps/web/src/app/features/dashboard/dashboard-page.component.ts
@@ -485,7 +485,9 @@ type RefreshState =
 export class DashboardPageComponent {
   private readonly runtimeSession = inject(RuntimeSessionService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly runtimeState = this.runtimeSession.watchState(this.destroyRef);
+  private readonly runtimeState = this.runtimeSession.watchState(
+    this.destroyRef
+  );
 
   readonly expandedIssues = signal(new Set<string>());
   readonly refreshState = signal<RefreshState>({ kind: "idle" });

--- a/apps/web/src/app/features/issues/issue-detail-page.component.ts
+++ b/apps/web/src/app/features/issues/issue-detail-page.component.ts
@@ -292,15 +292,17 @@ export class IssueDetailPageComponent {
     null;
 
   readonly issueIdentifier = signal("unknown");
-  readonly issueResource = signal<RuntimeResourceConnection<RuntimeIssueApiResponse> | null>(
-    null
+  readonly issueResource =
+    signal<RuntimeResourceConnection<RuntimeIssueApiResponse> | null>(null);
+  readonly issueLoadState = computed(
+    () =>
+      this.issueResource()?.loadState() ?? {
+        snapshot: null,
+        error: null,
+        initialLoadPending: true,
+        refreshPending: false
+      }
   );
-  readonly issueLoadState = computed(() => this.issueResource()?.loadState() ?? {
-    snapshot: null,
-    error: null,
-    initialLoadPending: true,
-    refreshPending: false
-  });
   readonly state = computed<IssueState>(() => {
     const loadState = this.issueLoadState();
     if (loadState.initialLoadPending && loadState.snapshot === null) {
@@ -345,7 +347,8 @@ export class IssueDetailPageComponent {
         const identifier = params.get("id") ?? "unknown";
         this.issueIdentifier.set(identifier);
         this.currentIssueResource?.destroy();
-        this.currentIssueResource = this.runtimeSession.connectIssue(identifier);
+        this.currentIssueResource =
+          this.runtimeSession.connectIssue(identifier);
         this.issueResource.set(this.currentIssueResource);
       });
   }

--- a/apps/web/src/app/shared/api/runtime-api.service.ts
+++ b/apps/web/src/app/shared/api/runtime-api.service.ts
@@ -27,22 +27,28 @@ export class RuntimeApiService {
   loadStateSnapshot(): Observable<RuntimeStateApiResponse> {
     return this.http
       .get<RuntimeStateApiResponse>("/api/v1/state")
-      .pipe(catchError((error: unknown) => throwError(() => toRuntimeUiError(error))));
+      .pipe(
+        catchError((error: unknown) =>
+          throwError(() => toRuntimeUiError(error))
+        )
+      );
   }
 
   loadDashboard(): Observable<DashboardViewModel> {
     return this.loadStateSnapshot().pipe(
-      map((response) => presentDashboardSnapshot(response)),
+      map((response) => presentDashboardSnapshot(response))
     );
   }
 
   loadRuns(): Observable<RunsViewModel> {
     return this.loadStateSnapshot().pipe(
-      map((response) => presentRunsSnapshot(response)),
+      map((response) => presentRunsSnapshot(response))
     );
   }
 
-  loadIssueSnapshot(issueIdentifier: string): Observable<RuntimeIssueApiResponse> {
+  loadIssueSnapshot(
+    issueIdentifier: string
+  ): Observable<RuntimeIssueApiResponse> {
     return this.http
       .get<RuntimeIssueApiResponse>(
         `/api/v1/${encodeURIComponent(issueIdentifier)}`

--- a/apps/web/src/app/shared/api/runtime-session.service.ts
+++ b/apps/web/src/app/shared/api/runtime-session.service.ts
@@ -1,4 +1,10 @@
-import { DestroyRef, Injectable, Signal, WritableSignal, signal } from "@angular/core";
+import {
+  DestroyRef,
+  Injectable,
+  Signal,
+  WritableSignal,
+  signal
+} from "@angular/core";
 import { Observable, Subscription, tap } from "rxjs";
 
 import { RuntimeApiService } from "./runtime-api.service";
@@ -27,7 +33,9 @@ type RuntimeManagedResource<TSnapshot extends RuntimeManagedSnapshot> = {
   refreshQueued: boolean;
 };
 
-export interface RuntimeResourceHandle<TSnapshot extends RuntimeManagedSnapshot> {
+export interface RuntimeResourceHandle<
+  TSnapshot extends RuntimeManagedSnapshot
+> {
   loadState: Signal<RuntimeLoadState<TSnapshot>>;
   refresh: () => void;
 }
@@ -62,12 +70,11 @@ export class RuntimeSessionService {
   private readonly eventErrorListener = () => this.handleEventStreamError();
   private browserListenersActive = false;
   private eventSource: EventSource | null = null;
-  private eventSourceReconnectHandle: ReturnType<typeof globalThis.setTimeout> | null =
-    null;
+  private eventSourceReconnectHandle: ReturnType<
+    typeof globalThis.setTimeout
+  > | null = null;
 
-  constructor(
-    private readonly api: RuntimeApiService
-  ) {
+  constructor(private readonly api: RuntimeApiService) {
     this.stateResource = this.createResource("state", () =>
       this.api.loadStateSnapshot()
     );
@@ -93,13 +100,14 @@ export class RuntimeSessionService {
   ): RuntimeResourceConnection<RuntimeIssueApiResponse> {
     const existingResource = this.issueResources.get(issueIdentifier);
     const resource =
-      existingResource ??
-      this.createIssueResource(issueIdentifier);
+      existingResource ?? this.createIssueResource(issueIdentifier);
     return this.connectResource(resource);
   }
 
   requestRefresh(): Observable<RefreshReceiptViewModel> {
-    return this.api.requestRefresh().pipe(tap(() => this.refreshActiveResources()));
+    return this.api
+      .requestRefresh()
+      .pipe(tap(() => this.refreshActiveResources()));
   }
 
   private createIssueResource(
@@ -330,16 +338,26 @@ export class RuntimeSessionService {
   private handleInvalidation(event: RuntimeInvalidationEvent): void {
     const issueIdentifiers = event.issue_identifiers ?? [];
     const revision = typeof event.revision === "number" ? event.revision : null;
-    const stateRevision = getSnapshotRevision(this.stateResource.loadState().snapshot);
+    const stateRevision = getSnapshotRevision(
+      this.stateResource.loadState().snapshot
+    );
 
-    if (this.stateResource.watchCount > 0 && shouldRefreshForRevision(stateRevision, revision)) {
+    if (
+      this.stateResource.watchCount > 0 &&
+      shouldRefreshForRevision(stateRevision, revision)
+    ) {
       this.fetchResource(this.stateResource);
     }
 
     if (issueIdentifiers.length === 0) {
       for (const resource of this.issueResources.values()) {
-        const issueRevision = getSnapshotRevision(resource.loadState().snapshot);
-        if (resource.watchCount > 0 && shouldRefreshForRevision(issueRevision, revision)) {
+        const issueRevision = getSnapshotRevision(
+          resource.loadState().snapshot
+        );
+        if (
+          resource.watchCount > 0 &&
+          shouldRefreshForRevision(issueRevision, revision)
+        ) {
           this.fetchResource(resource);
         }
       }
@@ -412,7 +430,8 @@ export function parseRuntimeInvalidationEvent(
         typeof parsed.revision === "number" ? parsed.revision : undefined,
       issue_identifiers: Array.isArray(parsed.issue_identifiers)
         ? parsed.issue_identifiers.filter(
-            (value): value is string => typeof value === "string" && value.length > 0
+            (value): value is string =>
+              typeof value === "string" && value.length > 0
           )
         : undefined
     };


### PR DESCRIPTION
## Summary
- allow dispatch config validation to accept complete Plane configs while preserving explicit missing-field errors
- surface unsupported Plane startup failures through the management command startup validation path
- expand workflow runtime and management command coverage for Plane startup validation and logging

## Testing
- env -u LINEAR_API_KEY -u SYMPHONY_RUNTIME_SNAPSHOT_PATH -u SYMPHONY_RUNTIME_REFRESH_REQUEST_PATH -u SYMPHONY_RUNTIME_RECOVERY_PATH -u SYMPHONY_WORKFLOW_PATH -u VIRTUAL_ENV uv run pytest apps/api/tests/unit/workflow/test_config.py apps/api/tests/unit/workflow/test_runtime.py apps/api/tests/unit/orchestrator/test_core.py apps/api/tests/unit/management/test_run_orchestrator.py -q
- make lint-api
- make typecheck-api