### PR TITLE
Migrate Plane tracker reads to work-items

### DIFF
--- a/apps/api/symphony/tracker/README.md
+++ b/apps/api/symphony/tracker/README.md
@@ -24,10 +24,15 @@ points, and the Symphony-owned tracker mutation contract.
   current mutation backend implementation used by the factory.
 - `plane.py`: Plane payload normalization into the shared `Issue` model.
 - `plane_client.py`: Plane REST transport and issue-page helpers built around `api_base_url`,
-  `workspace_slug`, `project_id`, and `X-API-Key`. Plane-backed pull-request links deliberately
-  round-trip only the repository-owned `id`, `title`, and `url` fields; `subtitle` and custom
-  metadata are normalized away because Plane's `/links/` write surface does not accept them as
-  stable caller-owned fields.
+  `workspace_slug`, `project_id`, and `X-API-Key`. Plane read paths target the supported
+  `/work-items/` surface. Because raw work-item payloads default `state` and `project` to scalar
+  ids instead of nested objects, the adapter keeps `expand=state,project,labels,blocked_by_issues`
+  on read requests so the normalizer still receives the names and identifiers Symphony needs. When
+  a work-item payload omits plain-text description fields and only returns `description_html`,
+  `plane.py` strips that HTML to keep `Issue.description` text-only. Plane-backed pull-request
+  links deliberately round-trip only the repository-owned `id`, `title`, and `url` fields;
+  `subtitle` and custom metadata are normalized away because Plane's `/links/` write surface does
+  not accept them as stable caller-owned fields.
 
 ## Design notes
 

--- a/apps/api/symphony/tracker/__init__.py
+++ b/apps/api/symphony/tracker/__init__.py
@@ -30,6 +30,7 @@ from .plane_client import (
     PlaneTrackerClient,
     PlaneTransportResponse,
     build_plane_issue_collection_url,
+    build_plane_work_item_collection_url,
 )
 from .write_contract import (
     TrackerAttachment,
@@ -109,6 +110,7 @@ __all__ = [
     "TrackerWorkflowState",
     "UPDATE_ISSUE_STATE_MUTATION",
     "build_plane_issue_collection_url",
+    "build_plane_work_item_collection_url",
     "build_tracker_mutation_backend",
     "build_tracker_read_client",
     "build_tracker_mutation_service",

--- a/apps/api/symphony/tracker/plane.py
+++ b/apps/api/symphony/tracker/plane.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from datetime import datetime
+from html.parser import HTMLParser
 from typing import Any
 
 from .models import Issue, IssueBlocker
@@ -78,12 +79,19 @@ def _extract_title(payload: Mapping[str, Any]) -> str:
 
 
 def _extract_description(payload: Mapping[str, Any]) -> str | None:
-    return _optional_string(
+    text_description = _optional_string(
         payload.get("description_stripped")
         or payload.get("descriptionStripped")
         or payload.get("description_text")
         or payload.get("description")
     )
+    if text_description is not None:
+        return text_description
+
+    html_description = _optional_string(payload.get("description_html"))
+    if html_description is None:
+        return None
+    return _strip_html_description(html_description)
 
 
 def _extract_branch_name(payload: Mapping[str, Any]) -> str | None:
@@ -230,3 +238,34 @@ def _iter_nodes(value: Any) -> Iterable[Any]:
     if isinstance(value, list):
         return value
     return ()
+
+
+def _strip_html_description(value: str) -> str | None:
+    parser = _HTMLTextExtractor()
+    parser.feed(value)
+    parser.close()
+
+    raw_text = parser.get_text()
+    normalized_lines = [line.strip() for line in raw_text.splitlines()]
+    text = "\n".join(line for line in normalized_lines if line)
+    return text or None
+
+
+class _HTMLTextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"br", "hr"}:
+            self._parts.append("\n")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"div", "li", "p", "section", "tr"}:
+            self._parts.append("\n")
+
+    def handle_data(self, data: str) -> None:
+        self._parts.append(data)
+
+    def get_text(self) -> str:
+        return "".join(self._parts)

--- a/apps/api/symphony/tracker/plane_client.py
+++ b/apps/api/symphony/tracker/plane_client.py
@@ -23,8 +23,6 @@ from .write_contract import (
 
 DEFAULT_PLANE_TIMEOUT_MS = 30_000
 DEFAULT_PLANE_PAGE_SIZE = 50
-PLANE_ISSUES_PATH_TEMPLATE = "/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/"
-PLANE_ISSUE_PATH_TEMPLATE = f"{PLANE_ISSUES_PATH_TEMPLATE}{{issue_id}}/"
 PLANE_WORK_ITEMS_PATH_TEMPLATE = (
     "/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/"
 )
@@ -35,7 +33,7 @@ PLANE_WORK_ITEM_LINK_PATH_TEMPLATE = f"{PLANE_WORK_ITEM_LINKS_PATH_TEMPLATE}{{li
 PLANE_PROJECT_STATES_PATH_TEMPLATE = (
     "/api/v1/workspaces/{workspace_slug}/projects/{project_id}/states/"
 )
-PLANE_ISSUE_EXPAND = "state,project,labels,blocked_by_issues"
+PLANE_WORK_ITEM_EXPAND = "state,project,labels,blocked_by_issues"
 
 
 class PlaneAPIError(Exception):
@@ -127,7 +125,7 @@ class PlaneTrackerClient:
         for issue_id in requested_issue_ids:
             issue_payload = self._fetch_optional_issue_json(
                 issue_id=issue_id,
-                query_params={"expand": PLANE_ISSUE_EXPAND},
+                query_params={"expand": PLANE_WORK_ITEM_EXPAND},
             )
             if issue_payload is None:
                 continue
@@ -235,7 +233,7 @@ class PlaneTrackerClient:
         query_params: Mapping[str, object] | None = None,
     ) -> PlaneIssuePage:
         payload = self._fetch_json(
-            path=PLANE_ISSUES_PATH_TEMPLATE.format(
+            path=PLANE_WORK_ITEMS_PATH_TEMPLATE.format(
                 workspace_slug=quote(self.tracker_config.workspace_slug or "", safe=""),
                 project_id=quote(self.tracker_config.project_id or "", safe=""),
             ),
@@ -248,7 +246,7 @@ class PlaneTrackerClient:
         return _extract_issue_page(payload)
 
     def build_issue_collection_url(self) -> str:
-        return build_plane_issue_collection_url(self.tracker_config)
+        return build_plane_work_item_collection_url(self.tracker_config)
 
     def _fetch_json(
         self,
@@ -298,10 +296,10 @@ class PlaneTrackerClient:
         response = self._send_request(
             transport=transport,
             method="GET",
-            path=PLANE_ISSUE_PATH_TEMPLATE.format(
+            path=PLANE_WORK_ITEM_PATH_TEMPLATE.format(
                 workspace_slug=quote(self.tracker_config.workspace_slug or "", safe=""),
                 project_id=quote(self.tracker_config.project_id or "", safe=""),
-                issue_id=quote(issue_id, safe=""),
+                work_item_id=quote(issue_id, safe=""),
             ),
             query_params=query_params,
             json_body=None,
@@ -316,12 +314,12 @@ class PlaneTrackerClient:
 
     def _fetch_issue_reference_by_id(self, issue_id: str) -> TrackerIssueReference:
         payload = self._fetch_json(
-            path=PLANE_ISSUE_PATH_TEMPLATE.format(
+            path=PLANE_WORK_ITEM_PATH_TEMPLATE.format(
                 workspace_slug=quote(self.tracker_config.workspace_slug or "", safe=""),
                 project_id=quote(self.tracker_config.project_id or "", safe=""),
-                issue_id=quote(issue_id, safe=""),
+                work_item_id=quote(issue_id, safe=""),
             ),
-            query_params={"expand": PLANE_ISSUE_EXPAND},
+            query_params={"expand": PLANE_WORK_ITEM_EXPAND},
         )
         return _normalize_issue_reference(
             payload,
@@ -368,13 +366,13 @@ class PlaneTrackerClient:
     def _fetch_cursor_issue_page(self, *, cursor: str | None) -> PlaneIssuePage:
         query_params: dict[str, object] = {
             "per_page": DEFAULT_PLANE_PAGE_SIZE,
-            "expand": PLANE_ISSUE_EXPAND,
+            "expand": PLANE_WORK_ITEM_EXPAND,
         }
         if cursor is not None:
             query_params["cursor"] = cursor
 
         payload = self._fetch_json(
-            path=PLANE_ISSUES_PATH_TEMPLATE.format(
+            path=PLANE_WORK_ITEMS_PATH_TEMPLATE.format(
                 workspace_slug=quote(self.tracker_config.workspace_slug or "", safe=""),
                 project_id=quote(self.tracker_config.project_id or "", safe=""),
             ),
@@ -411,14 +409,18 @@ class PlaneTrackerClient:
         return None
 
 
-def build_plane_issue_collection_url(tracker_config: PlaneTrackerConfig) -> str:
+def build_plane_work_item_collection_url(tracker_config: PlaneTrackerConfig) -> str:
     return _join_base_url(
         tracker_config.api_base_url or "",
-        PLANE_ISSUES_PATH_TEMPLATE.format(
+        PLANE_WORK_ITEMS_PATH_TEMPLATE.format(
             workspace_slug=quote(tracker_config.workspace_slug or "", safe=""),
             project_id=quote(tracker_config.project_id or "", safe=""),
         ),
     )
+
+
+def build_plane_issue_collection_url(tracker_config: PlaneTrackerConfig) -> str:
+    return build_plane_work_item_collection_url(tracker_config)
 
 
 def _default_plane_transport(

--- a/apps/api/tests/unit/tracker/test_plane.py
+++ b/apps/api/tests/unit/tracker/test_plane.py
@@ -16,7 +16,7 @@ def test_normalize_plane_issue_normalizes_full_issue_payload() -> None:
             "priority": "high",
             "state": {"name": "Todo"},
             "branch_name": "feature/eng-123",
-            "url": "https://plane.example/engineering/issues/123",
+            "url": "https://plane.example/engineering/work-items/ENG-123",
             "project": {"identifier": "ENG"},
             "labels": [
                 {"name": "Backend"},
@@ -42,7 +42,7 @@ def test_normalize_plane_issue_normalizes_full_issue_payload() -> None:
     assert issue.priority == 2
     assert issue.state == "Todo"
     assert issue.branch_name == "feature/eng-123"
-    assert issue.url == "https://plane.example/engineering/issues/123"
+    assert issue.url == "https://plane.example/engineering/work-items/ENG-123"
     assert issue.labels == ("backend", "needs review")
     assert issue.blocked_by == (
         IssueBlocker(
@@ -91,6 +91,40 @@ def test_normalize_plane_issue_accepts_missing_optional_fields() -> None:
     assert issue.blocked_by == ()
     assert issue.created_at is None
     assert issue.updated_at is None
+
+
+def test_normalize_plane_issue_falls_back_to_supported_work_item_html_description() -> None:
+    issue = normalize_plane_issue(
+        {
+            "id": "issue-9",
+            "sequence_id": 9,
+            "name": "Work item payload",
+            "description_html": "<div>First line</div><p>Second &amp; third</p>",
+            "state": {"name": "Todo"},
+            "project": {"identifier": "ENG"},
+            "blockedBy": {
+                "nodes": [
+                    {
+                        "relatedIssue": {
+                            "id": "issue-7",
+                            "sequenceId": "7",
+                            "projectDetail": {"identifier": "ENG"},
+                            "stateDetail": {"name": "Blocked"},
+                        }
+                    }
+                ]
+            },
+        }
+    )
+
+    assert issue.description == "First line\nSecond & third"
+    assert issue.blocked_by == (
+        IssueBlocker(
+            id="issue-7",
+            identifier="ENG-7",
+            state="Blocked",
+        ),
+    )
 
 
 def test_normalize_plane_issue_maps_named_priorities_and_blank_values() -> None:

--- a/apps/api/tests/unit/tracker/test_plane_client.py
+++ b/apps/api/tests/unit/tracker/test_plane_client.py
@@ -12,7 +12,7 @@ from symphony.tracker import (
     PlanePayloadError,
     PlaneTrackerClient,
     PlaneTransportResponse,
-    build_plane_issue_collection_url,
+    build_plane_work_item_collection_url,
 )
 from symphony.tracker.plane_client import DEFAULT_PLANE_PAGE_SIZE
 from symphony.workflow.config import PlaneTrackerConfig
@@ -114,7 +114,7 @@ def make_state_payload(
     }
 
 
-def test_build_plane_issue_collection_url_preserves_base_subpath_and_quotes_segments() -> None:
+def test_build_plane_work_item_collection_url_preserves_base_subpath_and_quotes_segments() -> None:
     config = PlaneTrackerConfig(
         kind="plane",
         api_base_url="https://plane.example/root",
@@ -125,11 +125,11 @@ def test_build_plane_issue_collection_url_preserves_base_subpath_and_quotes_segm
         terminal_states=("Done",),
     )
 
-    url = build_plane_issue_collection_url(config)
+    url = build_plane_work_item_collection_url(config)
 
     assert (
         url
-        == "https://plane.example/root/api/v1/workspaces/engineering%20team/projects/project%2F123/issues/"
+        == "https://plane.example/root/api/v1/workspaces/engineering%20team/projects/project%2F123/work-items/"
     )
 
 
@@ -142,7 +142,7 @@ def test_fetch_issue_page_sends_auth_headers_and_parses_next_offset() -> None:
                     "count": 1,
                     "next": (
                         "https://plane.example/self-hosted/api/v1/workspaces/engineering/"
-                        "projects/project-123/issues/?limit=50&offset=50"
+                        "projects/project-123/work-items/?limit=50&offset=50"
                     ),
                     "results": [
                         {
@@ -170,7 +170,7 @@ def test_fetch_issue_page_sends_auth_headers_and_parses_next_offset() -> None:
     assert len(transport.calls) == 1
     assert (
         transport.calls[0]["url"]
-        == "https://plane.example/self-hosted/api/v1/workspaces/engineering/projects/project-123/issues/"
+        == "https://plane.example/self-hosted/api/v1/workspaces/engineering/projects/project-123/work-items/"
     )
     assert transport.calls[0]["method"] == "GET"
     assert transport.calls[0]["headers"] == {
@@ -234,7 +234,7 @@ def test_fetch_issue_page_maps_non_2xx_status_to_typed_error() -> None:
         json.dumps({"count": 1}),
         json.dumps({"results": ["bad-node"]}),
         json.dumps({"results": [], "count": "1"}),
-        json.dumps({"results": [], "next": "https://plane.example/issues/?limit=50"}),
+        json.dumps({"results": [], "next": "https://plane.example/work-items/?limit=50"}),
     ],
 )
 def test_fetch_issue_page_maps_malformed_payloads_to_typed_error(body: str) -> None:
@@ -479,15 +479,15 @@ def test_fetch_issue_states_by_ids_fetches_issue_detail_and_skips_missing_ids() 
     assert [call["url"] for call in transport.calls] == [
         (
             "https://plane.example/self-hosted/api/v1/workspaces/engineering/projects/"
-            "project-123/issues/issue-1/"
+            "project-123/work-items/issue-1/"
         ),
         (
             "https://plane.example/self-hosted/api/v1/workspaces/engineering/projects/"
-            "project-123/issues/missing-issue/"
+            "project-123/work-items/missing-issue/"
         ),
         (
             "https://plane.example/self-hosted/api/v1/workspaces/engineering/projects/"
-            "project-123/issues/issue-3/"
+            "project-123/work-items/issue-3/"
         ),
     ]
     assert all(
@@ -991,7 +991,7 @@ def test_update_issue_state_patches_work_item_and_refetches_issue() -> None:
             "method": "GET",
             "url": (
                 "https://plane.example/self-hosted/api/v1/workspaces/engineering/projects/"
-                "project-123/issues/issue-123/"
+                "project-123/work-items/issue-123/"
             ),
             "headers": {
                 "Accept": "application/json",

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1200,8 +1200,8 @@ Plane-specific requirements for `tracker.kind == "plane"`:
 - `tracker.kind == "plane"`
 - Base URL comes from `tracker.api_base_url`
 - Auth token is sent in the `X-API-Key` header
-- Issue collection path:
-  `/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/`
+- Work-item collection path:
+  `/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/`
 - `tracker.workspace_slug` and `tracker.project_id` map directly to those path segments
 - Pagination follows the `next_cursor` field in each response; iteration stops when `next_cursor`
   is absent or empty
@@ -1221,6 +1221,11 @@ Additional normalization details:
 - `blocked_by` -> derived from inverse relations where relation type is `blocks`
 - `priority` -> integer only (non-integers become null)
 - `created_at` and `updated_at` -> parse ISO-8601 timestamps
+- Plane work-item reads should expand `state`, `project`, and `labels` because the raw
+  `/work-items/` payload can represent `state` and `project` as scalar ids rather than nested
+  objects.
+- When a Plane work-item payload omits plain-text description fields and only provides
+  `description_html`, strip the HTML to plain text before assigning `Issue.description`.
 
 ### 11.4 Error Handling Contract
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -196,7 +196,7 @@ export PLANE_PROJECT_ID=88c2d97c-a6ad-4012-b526-5577c0d7c769
 
 `api_base_url` points at the root of your self-hosted Plane deployment.
 `workspace_slug` and `project_id` map directly to
-`/api/v1/workspaces/{workspace_slug}/projects/{project_id}/issues/`.
+`/api/v1/workspaces/{workspace_slug}/projects/{project_id}/work-items/`.
 
 The environment variable names above (`PLANE_API_BASE_URL`, `PLANE_API_KEY`, `PLANE_WORKSPACE`,
 `PLANE_PROJECT_ID`) are conventional — the runtime only sees the resolved string value, so any


### PR DESCRIPTION
## Summary
- switch Plane tracker read URLs from deprecated `/issues/` endpoints to the supported `/work-items/` surface
- preserve normalized issue data for work-item reads by keeping expanded state/project relations and stripping `description_html` when plain text is missing
- refresh Plane tracker tests and docs to cover the supported path plus the payload-shape differences uncovered during the migration

## Testing
- uv run pytest apps/api/tests/unit/tracker/test_plane.py apps/api/tests/unit/tracker/test_plane_client.py -q
- make format
- make lint
- make typecheck
- make test

## Manual QA Plan
- Not applicable; this is a backend tracker transport and documentation change validated by automated tests.
